### PR TITLE
Add option to disable forced refresh for initial tokens (#52)

### DIFF
--- a/lib/keycloak.d.ts
+++ b/lib/keycloak.d.ts
@@ -112,6 +112,12 @@ export interface KeycloakInitOptions {
 	idToken?: string;
 
 	/**
+	 * Disables forced refresh for the initial tokens and instead checks if
+	 * they're still valid (only together with `token` and `refreshToken`)
+	 */
+	disableInitialForcedRefresh?: boolean;
+
+	/**
 	 * Set an initial value for skew between local time and Keycloak server in
 	 * seconds (only together with `token` or `refreshToken`).
 	 */

--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -299,7 +299,8 @@ function Keycloak (config) {
                         });
                     });
                 } else {
-                    kc.updateToken(-1).then(function() {
+                    var minValidity = initOptions.disableInitialForcedRefresh ? undefined : -1;
+                    kc.updateToken(minValidity).then(function() {
                         kc.onAuthSuccess && kc.onAuthSuccess();
                         initPromise.setSuccess();
                     }).catch(function(error) {


### PR DESCRIPTION
Adds a new option for the initialization to use the initial tokens without a forced request, if the are still valid.

Closes #52