### PR TITLE
Remove `acrValues` from initialization options

### DIFF
--- a/docs/guides/securing-apps/javascript-adapter.adoc
+++ b/docs/guides/securing-apps/javascript-adapter.adoc
@@ -401,7 +401,6 @@ to {project_name} will contain the scope parameter `scope=openid address phone`.
 * pkceMethod - The method for Proof Key Code Exchange (https://datatracker.ietf.org/doc/html/rfc7636[PKCE]) to use. Configuring this value enables the PKCE mechanism. Available options:
     - "S256" - The SHA256 based PKCE method (default)
     - false - PKCE is disabled.
-* acrValues - Generates the `acr_values` parameter which refers to authentication context class reference and allows clients to declare the required assurance level requirements, e.g. authentication mechanisms. See https://openid.net/specs/openid-connect-modrna-authentication-1_0.html#acr_values[Section 4. acr_values request values and level of assurance in OpenID Connect MODRNA Authentication Profile 1.0].
 * messageReceiveTimeout - Set a timeout in milliseconds for waiting for message responses from the Keycloak server. This is used, for example, when waiting for a message during 3rd party cookies check. The default value is 10000.
 * locale - When onLoad is 'login-required', sets the 'ui_locales' query param in compliance with https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest[section 3.1.2.1 of the OIDC 1.0 specification].
 

--- a/lib/keycloak.d.ts
+++ b/lib/keycloak.d.ts
@@ -171,13 +171,6 @@ export interface KeycloakInitOptions {
 	pkceMethod?: KeycloakPkceMethod;
 
 	/**
-	 * Configures the 'acr_values' query param in compliance with section 3.1.2.1
-	 * of the OIDC 1.0 specification.
-	 * Used to tell Keycloak what level of authentication the user needs.
-	 */
-	acrValues?: string;
-
-	/**
 	 * Enables logging messages from Keycloak to the console.
 	 * @default false
 	 */

--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -173,10 +173,6 @@ function Keycloak (config) {
             kc.scope = initOptions.scope;
         }
 
-        if (typeof initOptions.acrValues === 'string') {
-            kc.acrValues = initOptions.acrValues;
-        }
-
         if (typeof initOptions.messageReceiveTimeout === 'number' && initOptions.messageReceiveTimeout > 0) {
             kc.messageReceiveTimeout = initOptions.messageReceiveTimeout;
         } else {
@@ -458,8 +454,8 @@ function Keycloak (config) {
             params.append('claims', buildClaimsParameter(options.acr));
         }
 
-        if (options?.acrValues || kc.acrValues) {
-            params.append('acr_values', options.acrValues || kc.acrValues);
+        if (options?.acrValues) {
+            params.append('acr_values', options.acrValues);
         }
 
         if (kc.pkceMethod) {


### PR DESCRIPTION
Removes the `acrValues` option during initialization, as it has never worked correctly. This is technically a breaking change, but because the functionality was broken since its first incarnation, we can safely assume that this will have little to no impact.

This is part of a larger effort to get rid of options that are duplicated between `init()` and `createLoginUrl()` (or `login()`). These duplications only exist for those use cases where calling `init()` triggers a `login()`, which is a side effect that I want to explicitly get rid of in the future.

Closes #72