### PR TITLE
Refactor `createAccountUrl()` to use standardized URL APIs

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -1,6 +1,6 @@
 // @ts-check
 /**
- * @import {KeycloakLoginOptions, KeycloakLogoutOptions, KeycloakRegisterOptions} from "./keycloak.d.ts"
+ * @import {KeycloakAccountOptions, KeycloakLoginOptions, KeycloakLogoutOptions, KeycloakRegisterOptions} from "./keycloak.d.ts"
  */
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates
@@ -518,16 +518,23 @@ function Keycloak (config) {
         return await kc.createLoginUrl({ ...options, action: 'register' });
     }
 
+    /**
+     * @param {KeycloakAccountOptions} [options]
+     * @returns {string}
+     */
     kc.createAccountUrl = function(options) {
-        var realm = getRealmUrl();
-        var url = undefined;
-        if (typeof realm !== 'undefined') {
-            url = realm
-            + '/account'
-            + '?referrer=' + encodeURIComponent(kc.clientId)
-            + '&referrer_uri=' + encodeURIComponent(adapter.redirectUri(options));
+        const url = getRealmUrl();
+
+        if (!url) {
+            throw new Error('Unable to create account URL, make sure the adapter not is configured using a generic OIDC provider.');
         }
-        return url;
+
+        const params = new URLSearchParams([
+            ['referrer', kc.clientId],
+            ['referrer_uri', adapter.redirectUri(options)]
+        ]);
+
+        return `${url}/account?${params.toString()}`;
     }
 
     kc.accountManagement = function() {

--- a/test/support/test-executor.ts
+++ b/test/support/test-executor.ts
@@ -1,6 +1,6 @@
 import type { ConsoleMessage, Page } from 'playwright'
 import type Keycloak from '../../lib/keycloak.d.ts'
-import type { KeycloakConfig, KeycloakInitOptions, KeycloakLoginOptions, KeycloakLogoutOptions, KeycloakProfile, KeycloakRegisterOptions, KeycloakTokenParsed } from '../../lib/keycloak.d.ts'
+import type { KeycloakAccountOptions, KeycloakConfig, KeycloakInitOptions, KeycloakLoginOptions, KeycloakLogoutOptions, KeycloakProfile, KeycloakRegisterOptions, KeycloakTokenParsed } from '../../lib/keycloak.d.ts'
 import { AUTHORIZED_PASSWORD, AUTHORIZED_USERNAME, CLIENT_ID } from './common.ts'
 import type { TestOptions } from './testbed.ts'
 
@@ -138,6 +138,13 @@ export class TestExecutor {
     await this.#assertInstantiated()
     return await this.#page.evaluate(async (options) => {
       return await ((globalThis as any).keycloak as Keycloak).createRegisterUrl(options)
+    }, options)
+  }
+
+  async createAccountUrl (options?: KeycloakAccountOptions): Promise<string> {
+    await this.#assertInstantiated()
+    return await this.#page.evaluate(async (options) => {
+      return ((globalThis as any).keycloak as Keycloak).createAccountUrl(options)
     }, options)
   }
 

--- a/test/tests/account-url.spec.ts
+++ b/test/tests/account-url.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from '@playwright/test'
+import { CLIENT_ID } from '../support/common.ts'
+import { createTestBed, test } from '../support/testbed.ts'
+
+test('creates an account URL with all options', async ({ page, appUrl, authServerUrl }) => {
+  const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.initializeAdapter(executor.defaultInitOptions())
+  const redirectUri = new URL('/foo/bar', appUrl)
+  const accountUrl = new URL(await executor.createAccountUrl({
+    redirectUri: redirectUri.toString()
+  }))
+  expect(accountUrl.pathname).toBe(`/realms/${realm}/account`)
+  expect(accountUrl.searchParams.get('referrer')).toBe(CLIENT_ID)
+  expect(accountUrl.searchParams.get('referrer_uri')).toBe(redirectUri.toString())
+})
+
+test('creates an account URL with default options', async ({ page, appUrl, authServerUrl }) => {
+  const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.initializeAdapter(executor.defaultInitOptions())
+  const accountUrl = new URL(await executor.createAccountUrl())
+  expect(accountUrl.pathname).toBe(`/realms/${realm}/account`)
+  expect(accountUrl.searchParams.get('referrer')).toBe(CLIENT_ID)
+  expect(accountUrl.searchParams.get('referrer_uri')).toBe(appUrl.toString())
+})
+
+test('throws creating an account URL with generic OIDC configuration', async ({ page, appUrl, authServerUrl }) => {
+  const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  const oidcProviderUrl = new URL(`/realms/${realm}`, authServerUrl)
+  await executor.instantiateAdapter({
+    clientId: CLIENT_ID,
+    oidcProvider: oidcProviderUrl.toString()
+  })
+  await executor.initializeAdapter(executor.defaultInitOptions())
+  await expect(executor.createAccountUrl()).rejects.toThrow('Unable to create account URL, make sure the adapter not is configured using a generic OIDC provider.')
+})


### PR DESCRIPTION
Refactors `createAccountUrl()` to use standardized URL APIs and adds test coverage. Additionally, this method now throws instead of returning `undefined` when a generic OIDC provider is used to better match the type-definition.

Closes #78