### PR TITLE
Replace `createPromise()` with standarized API and syntax

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -1,6 +1,6 @@
 // @ts-check
 /**
- * @import {KeycloakAccountOptions, KeycloakLoginOptions, KeycloakLogoutOptions, KeycloakProfile, KeycloakRegisterOptions} from "./keycloak.d.ts"
+ * @import {KeycloakAccountOptions, KeycloakInitOptions, KeycloakLoginOptions, KeycloakLogoutOptions, KeycloakProfile, KeycloakRegisterOptions} from "./keycloak.d.ts"
  */
 /*
  * Copyright 2016 Red Hat, Inc. and/or its affiliates
@@ -67,7 +67,11 @@ function Keycloak (config) {
         );
     }
 
-    kc.init = function (initOptions = {}) {
+    /**
+     * @param {KeycloakInitOptions} initOptions 
+     * @returns {Promise<boolean>}
+     */
+    kc.init = async function (initOptions = {}) {
         if (kc.didInitialize) {
             throw new Error("A 'Keycloak' instance can only be initialized once.");
         }
@@ -190,20 +194,10 @@ function Keycloak (config) {
             kc.flow = 'standard';
         }
 
-        var promise = createPromise();
+        async function onLoad() {
+            async function doLogin(prompt) {
+                const options = {};
 
-        var initPromise = createPromise();
-        initPromise.promise.then(function() {
-            kc.onReady && kc.onReady(kc.authenticated);
-            promise.setSuccess(kc.authenticated);
-        }).catch(function(error) {
-            promise.setError(error);
-        });
-
-        var configPromise = loadConfig();
-
-        function onLoad() {
-            var doLogin = function(prompt) {
                 if (!prompt) {
                     options.prompt = 'none';
                 }
@@ -211,128 +205,111 @@ function Keycloak (config) {
                 if (initOptions.locale) {
                     options.locale = initOptions.locale;
                 }
-                kc.login(options).then(function () {
-                    initPromise.setSuccess();
-                }).catch(function (error) {
-                    initPromise.setError(error);
-                });
+
+                await kc.login(options);
             }
 
-            var checkSsoSilently = async function() {
-                var ifrm = document.createElement("iframe");
-                var src = await kc.createLoginUrl({prompt: 'none', redirectUri: kc.silentCheckSsoRedirectUri});
-                ifrm.setAttribute("src", src);
-                ifrm.setAttribute("sandbox", "allow-storage-access-by-user-activation allow-scripts allow-same-origin");
-                ifrm.setAttribute("title", "keycloak-silent-check-sso");
-                ifrm.style.display = "none";
-                document.body.appendChild(ifrm);
+             async function checkSsoSilently() {
+                const iframe = document.createElement("iframe");
+                const src = await kc.createLoginUrl({ prompt: 'none', redirectUri: kc.silentCheckSsoRedirectUri });
+                iframe.setAttribute("src", src);
+                iframe.setAttribute("sandbox", "allow-storage-access-by-user-activation allow-scripts allow-same-origin");
+                iframe.setAttribute("title", "keycloak-silent-check-sso");
+                iframe.style.display = "none";
+                document.body.appendChild(iframe);
 
-                var messageCallback = function(event) {
-                    if (event.origin !== window.location.origin || ifrm.contentWindow !== event.source) {
-                        return;
-                    }
 
-                    var oauth = parseCallback(event.data);
-                    processCallback(oauth, initPromise);
+                return await new Promise((resolve, reject) => {
+                    async function messageCallback(event) {
+                        if (event.origin !== window.location.origin || iframe.contentWindow !== event.source) {
+                            return;
+                        }
 
-                    document.body.removeChild(ifrm);
-                    window.removeEventListener("message", messageCallback);
-                };
+                        const oauth = parseCallback(event.data);
 
-                window.addEventListener("message", messageCallback);
+                        try {
+                            await processCallback(oauth);
+                            resolve()
+                        } catch (error) {
+                            reject(error);
+                        }
+
+                        document.body.removeChild(iframe);
+                        window.removeEventListener("message", messageCallback);
+                    };
+
+                    window.addEventListener("message", messageCallback);
+                });
             };
 
-            var options = {};
             switch (initOptions.onLoad) {
                 case 'check-sso':
                     if (loginIframe.enable) {
-                        setupCheckLoginIframe().then(function() {
-                            checkLoginIframe().then(function (unchanged) {
-                                if (!unchanged) {
-                                    kc.silentCheckSsoRedirectUri ? checkSsoSilently() : doLogin(false);
-                                } else {
-                                    initPromise.setSuccess();
-                                }
-                            }).catch(function (error) {
-                                initPromise.setError(error);
-                            });
-                        });
+                        await setupCheckLoginIframe();
+                        const unchanged = await checkLoginIframe();
+
+                        if (!unchanged) {
+                            kc.silentCheckSsoRedirectUri ? await checkSsoSilently() : await doLogin(false);
+                        }
                     } else {
-                        kc.silentCheckSsoRedirectUri ? checkSsoSilently() : doLogin(false);
+                        kc.silentCheckSsoRedirectUri ? await checkSsoSilently() : await doLogin(false);
                     }
                     break;
                 case 'login-required':
-                    doLogin(true);
+                    await doLogin(true);
                     break;
                 default:
                     throw 'Invalid value for onLoad';
             }
         }
 
-        function processInit() {
-            var callback = parseCallback(window.location.href);
+        async function processInit() {
+            const callback = parseCallback(window.location.href);
 
             if (callback) {
                 window.history.replaceState(window.history.state, null, callback.newUrl);
             }
 
             if (callback && callback.valid) {
-                return setupCheckLoginIframe().then(function() {
-                    processCallback(callback, initPromise);
-                }).catch(function (error) {
-                    initPromise.setError(error);
-                });
+                await setupCheckLoginIframe();
+                await processCallback(callback);
+                return;
             }
 
             if (initOptions.token && initOptions.refreshToken) {
                 setToken(initOptions.token, initOptions.refreshToken, initOptions.idToken);
 
                 if (loginIframe.enable) {
-                    setupCheckLoginIframe().then(function() {
-                        checkLoginIframe().then(function (unchanged) {
-                            if (unchanged) {
-                                kc.onAuthSuccess && kc.onAuthSuccess();
-                                initPromise.setSuccess();
-                                scheduleCheckIframe();
-                            } else {
-                                initPromise.setSuccess();
-                            }
-                        }).catch(function (error) {
-                            initPromise.setError(error);
-                        });
-                    });
-                } else {
-                    kc.updateToken(-1).then(function() {
+                    await setupCheckLoginIframe();
+                    const unchanged = await checkLoginIframe();
+
+                    if (unchanged) {
                         kc.onAuthSuccess && kc.onAuthSuccess();
-                        initPromise.setSuccess();
-                    }).catch(function(error) {
+                        scheduleCheckIframe();
+                    }
+                } else {
+                    try {
+                        await kc.updateToken(-1);
+                        kc.onAuthSuccess && kc.onAuthSuccess();
+                    } catch (error) {
                         kc.onAuthError && kc.onAuthError();
                         if (initOptions.onLoad) {
-                            onLoad();
+                            await onLoad();
                         } else {
-                            initPromise.setError(error);
+                            throw error;
                         }
-                    });
+                    }
                 }
             } else if (initOptions.onLoad) {
-                onLoad();
-            } else {
-                initPromise.setSuccess();
+                await onLoad();
             }
         }
 
-        configPromise.then(function () {
-            check3pCookiesSupported()
-                .then(processInit)
-                .catch(function (error) {
-                    promise.setError(error);
-                });
-        });
-        configPromise.catch(function (error) {
-            promise.setError(error);
-        });
-
-        return promise.promise;
+        await loadConfig();
+        await check3pCookiesSupported()
+        await processInit();
+        kc.onReady && kc.onReady(kc.authenticated);
+        return kc.authenticated;
     }
 
     kc.login = function (options) {
@@ -529,7 +506,7 @@ function Keycloak (config) {
         const url = getRealmUrl();
 
         if (!url) {
-            throw new Error('Unable to create account URL, make sure the adapter not is configured using a generic OIDC provider.');
+            throw new Error('Unable to create account URL, make sure the adapter is not configured using a generic OIDC provider.');
         }
 
         const params = new URLSearchParams([
@@ -565,7 +542,7 @@ function Keycloak (config) {
         const realmUrl = getRealmUrl();
 
         if (!realmUrl) {
-            throw new Error('Unable to load user profile, make sure the adapter not is configured using a generic OIDC provider.');
+            throw new Error('Unable to load user profile, make sure the adapter is not configured using a generic OIDC provider.');
         }
 
         const url = `${realmUrl}/account`;
@@ -608,76 +585,70 @@ function Keycloak (config) {
         return expiresIn < 0;
     }
 
-    kc.updateToken = function(minValidity) {
-        var promise = createPromise();
-
+    kc.updateToken = async function(minValidity) {
         if (!kc.refreshToken) {
-            promise.setError();
-            return promise.promise;
+            throw new Error('Unable to update token, no refresh token available.');
         }
 
         minValidity = minValidity || 5;
 
-        var exec = function() {
-            var refreshToken = false;
-            if (minValidity === -1) {
-                refreshToken = true;
-                logInfo('[KEYCLOAK] Refreshing token: forced refresh');
-            } else if (!kc.tokenParsed || kc.isTokenExpired(minValidity)) {
-                refreshToken = true;
-                logInfo('[KEYCLOAK] Refreshing token: token expired');
-            }
+        if (loginIframe.enable) {
+            await checkLoginIframe();
+        }
+        
+        let refreshToken = false;
 
-            if (!refreshToken) {
-                promise.setSuccess(false);
-            } else {
-                refreshQueue.push(promise);
+        if (minValidity === -1) {
+            refreshToken = true;
+            logInfo('[KEYCLOAK] Refreshing token: forced refresh');
+        } else if (!kc.tokenParsed || kc.isTokenExpired(minValidity)) {
+            refreshToken = true;
+            logInfo('[KEYCLOAK] Refreshing token: token expired');
+        }
 
-                if (refreshQueue.length === 1) {
-                    const url = kc.endpoints.token();
-                    let timeLocal = new Date().getTime();
+        if (!refreshToken) {
+            return false;
+        }
 
-                    fetchRefreshToken(url, kc.refreshToken, kc.clientId)
-                    .then((response) => {
-                        logInfo('[KEYCLOAK] Token refreshed');
+        let resolve, reject;
+        const promise = new Promise((res, rej) => {
+            resolve = res;
+            reject = rej;
+        });
 
-                        timeLocal = (timeLocal + new Date().getTime()) / 2;
+        refreshQueue.push({ resolve, reject });
 
-                        setToken(response['access_token'], response['refresh_token'], response['id_token'], timeLocal);
+        if (refreshQueue.length === 1) {
+            const url = kc.endpoints.token();
+            let timeLocal = new Date().getTime();
 
-                        kc.onAuthRefreshSuccess && kc.onAuthRefreshSuccess();
-                        for (let p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
-                            p.setSuccess(true);
-                        }
-                    })
-                    .catch((error) => {
-                        logWarn('[KEYCLOAK] Failed to refresh token');
+            try {
+                const response = await fetchRefreshToken(url, kc.refreshToken, kc.clientId);
+                logInfo('[KEYCLOAK] Token refreshed');
 
-                        if (error instanceof NetworkError && error.response.status === 400) {
-                            kc.clearToken();
-                        }
+                timeLocal = (timeLocal + new Date().getTime()) / 2;
 
-                        kc.onAuthRefreshError && kc.onAuthRefreshError();
-                        for (let p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
-                            p.setError(error);
-                        }
-                    });
+                setToken(response['access_token'], response['refresh_token'], response['id_token'], timeLocal);
+
+                kc.onAuthRefreshSuccess && kc.onAuthRefreshSuccess();
+                for (let p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
+                    p.resolve(true);
+                }
+            } catch (error) {
+                logWarn('[KEYCLOAK] Failed to refresh token');
+
+                if (error instanceof NetworkError && error.response.status === 400) {
+                    kc.clearToken();
+                }
+
+                kc.onAuthRefreshError && kc.onAuthRefreshError();
+                for (let p = refreshQueue.pop(); p != null; p = refreshQueue.pop()) {
+                    p.reject(error);
                 }
             }
         }
 
-        if (loginIframe.enable) {
-            var iframePromise = checkLoginIframe();
-            iframePromise.then(function() {
-                exec();
-            }).catch(function(error) {
-                promise.setError(error);
-            });
-        } else {
-            exec();
-        }
-
-        return promise.promise;
+        return await promise;
     }
 
     kc.clearToken = function() {
@@ -690,32 +661,20 @@ function Keycloak (config) {
         }
     }
 
+    /**
+     * @returns {string | undefined}
+     */
     function getRealmUrl() {
-        if (typeof kc.authServerUrl !== 'undefined') {
-            if (kc.authServerUrl.charAt(kc.authServerUrl.length - 1) === '/') {
-                return kc.authServerUrl + 'realms/' + encodeURIComponent(kc.realm);
-            } else {
-                return kc.authServerUrl + '/realms/' + encodeURIComponent(kc.realm);
-            }
-        } else {
-            return undefined;
+        if (typeof kc.authServerUrl === 'undefined') {
+            return;
         }
+
+        return `${stripTrailingSlash(kc.authServerUrl)}/realms/${encodeURIComponent(kc.realm)}`;
     }
 
-    function getOrigin() {
-        if (!window.location.origin) {
-            return window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port: '');
-        } else {
-            return window.location.origin;
-        }
-    }
-
-    function processCallback(oauth, promise) {
-        var code = oauth.code;
-        var error = oauth.error;
-        var prompt = oauth.prompt;
-
-        var timeLocal = new Date().getTime();
+    async function processCallback(oauth) {
+        const { code, error, prompt } = oauth;
+        let timeLocal = new Date().getTime();
 
         if (oauth['kc_action_status']) {
             kc.onActionUpdate && kc.onActionUpdate(oauth['kc_action_status'], oauth['kc_action']);
@@ -724,33 +683,36 @@ function Keycloak (config) {
         if (error) {
             if (prompt !== 'none') {
                 if (oauth.error_description && oauth.error_description === "authentication_expired") {
-                    kc.login(oauth.loginOptions);
+                    await kc.login(oauth.loginOptions);
                 } else {
-                    var errorData = { error: error, error_description: oauth.error_description };
+                    const errorData = { error, error_description: oauth.error_description };
                     kc.onAuthError && kc.onAuthError(errorData);
-                    promise && promise.setError(errorData);
+                    throw errorData;
                 }
-            } else {
-                promise && promise.setSuccess();
             }
             return;
         } else if ((kc.flow !== 'standard') && (oauth.access_token || oauth.id_token)) {
-            authSuccess(oauth.access_token, null, oauth.id_token, true);
+            authSuccess(oauth.access_token, null, oauth.id_token);
+            kc.onAuthSuccess && kc.onAuthSuccess();
         }
 
         if ((kc.flow !== 'implicit') && code) {
-            fetchAccessToken(kc.endpoints.token(), code, kc.clientId, decodeURIComponent(oauth.redirectUri), oauth.pkceCodeVerifier)
-            .then((response) => {
-                authSuccess(response['access_token'], response['refresh_token'], response['id_token'], kc.flow === 'standard');
+            try {
+                const response = await fetchAccessToken(kc.endpoints.token(), code, kc.clientId, decodeURIComponent(oauth.redirectUri), oauth.pkceCodeVerifier)
+                authSuccess(response['access_token'], response['refresh_token'], response['id_token']);
+
+                if (kc.flow === 'standard') {
+                    kc.onAuthSuccess && kc.onAuthSuccess();
+                }
+
                 scheduleCheckIframe();
-            })
-            .catch((error) => {
+            } catch (error) {
                 kc.onAuthError && kc.onAuthError();
-                promise && promise.setError(error);
-            });
+                throw error;
+            }
         }
 
-        function authSuccess(accessToken, refreshToken, idToken, fulfillPromise) {
+        function authSuccess(accessToken, refreshToken, idToken) {
             timeLocal = (timeLocal + new Date().getTime()) / 2;
 
             setToken(accessToken, refreshToken, idToken, timeLocal);
@@ -758,132 +720,112 @@ function Keycloak (config) {
             if (useNonce && (kc.idTokenParsed && kc.idTokenParsed.nonce !== oauth.storedNonce)) {
                 logInfo('[KEYCLOAK] Invalid nonce, clearing token');
                 kc.clearToken();
-                promise && promise.setError();
-            } else {
-                if (fulfillPromise) {
-                    kc.onAuthSuccess && kc.onAuthSuccess();
-                    promise && promise.setSuccess();
-                }
+                throw new Error('Invalid nonce.');
             }
         }
 
     }
 
-    function loadConfig() {
-        var promise = createPromise();
-        var configUrl;
-
+    /**
+     * @returns {Promise<void>}
+     */
+    async function loadConfig() {
         if (typeof config === 'string') {
-            configUrl = config;
-        }
-
-        /**
-         * @param {OpenIdProviderMetadata | null} oidcConfiguration 
-         */
-        function setupOidcEndoints(oidcConfiguration) {
-            if (!oidcConfiguration) {
-                kc.endpoints = {
-                    authorize: function() {
-                        return getRealmUrl() + '/protocol/openid-connect/auth';
-                    },
-                    token: function() {
-                        return getRealmUrl() + '/protocol/openid-connect/token';
-                    },
-                    logout: function() {
-                        return getRealmUrl() + '/protocol/openid-connect/logout';
-                    },
-                    checkSessionIframe: function() {
-                        return getRealmUrl() + '/protocol/openid-connect/login-status-iframe.html';
-                    },
-                    thirdPartyCookiesIframe: function() {
-                        return getRealmUrl() + '/protocol/openid-connect/3p-cookies/step1.html';
-                    },
-                    register: function() {
-                        return getRealmUrl() + '/protocol/openid-connect/registrations';
-                    },
-                    userinfo: function() {
-                        return getRealmUrl() + '/protocol/openid-connect/userinfo';
-                    }
-                };
-            } else {
-                kc.endpoints = {
-                    authorize: function() {
-                        return oidcConfiguration.authorization_endpoint;
-                    },
-                    token: function() {
-                        return oidcConfiguration.token_endpoint;
-                    },
-                    logout: function() {
-                        if (!oidcConfiguration.end_session_endpoint) {
-                            throw "Not supported by the OIDC server";
-                        }
-                        return oidcConfiguration.end_session_endpoint;
-                    },
-                    checkSessionIframe: function() {
-                        if (!oidcConfiguration.check_session_iframe) {
-                            throw "Not supported by the OIDC server";
-                        }
-                        return oidcConfiguration.check_session_iframe;
-                    },
-                    register: function() {
-                        throw 'Redirection to "Register user" page not supported in standard OIDC mode';
-                    },
-                    userinfo: function() {
-                        if (!oidcConfiguration.userinfo_endpoint) {
-                            throw "Not supported by the OIDC server";
-                        }
-                        return oidcConfiguration.userinfo_endpoint;
-                    }
-                }
-            }
-        }
-
-        if (configUrl) {
-            fetchJsonConfig(configUrl)
-            .then((config) => {
-                kc.authServerUrl = config['auth-server-url'];
-                kc.realm = config.realm;
-                kc.clientId = config.resource;
-                setupOidcEndoints(null);
-                promise.setSuccess();
-            })
-            .catch((error) => {
-                promise.setError(error);
-            });
+            const jsonConfig = await fetchJsonConfig(config);
+            kc.authServerUrl = jsonConfig['auth-server-url'];
+            kc.realm = jsonConfig.realm;
+            kc.clientId = jsonConfig.resource;
+            setupEndpoints();
         } else {
             kc.clientId = config.clientId;
 
-            var oidcProvider = config['oidcProvider'];
-            if (!oidcProvider) {
+            if (config.oidcProvider) {
+                await loadOidcConfig(config.oidcProvider)
+            } else {
                 kc.authServerUrl = config.url;
                 kc.realm = config.realm;
-                setupOidcEndoints(null);
-                promise.setSuccess();
-            } else {
-                if (typeof oidcProvider === 'string') {
-                    var oidcProviderConfigUrl;
-                    if (oidcProvider.charAt(oidcProvider.length - 1) === '/') {
-                        oidcProviderConfigUrl = oidcProvider + '.well-known/openid-configuration';
-                    } else {
-                        oidcProviderConfigUrl = oidcProvider + '/.well-known/openid-configuration';
-                    }
-
-                    fetchOpenIdConfig(oidcProviderConfigUrl)
-                    .then((config) => {
-                        setupOidcEndoints(config);
-                        promise.setSuccess();
-                    })
-                    .catch((error) => {
-                        promise.setError(error);
-                    });
-                } else {
-                    setupOidcEndoints(oidcProvider);
-                    promise.setSuccess();
-                }
+                setupEndpoints();
             }
         }
+    }
 
-        return promise.promise;
+    /**
+     * @param {string | OpenIdProviderMetadata} oidcProvider 
+     * @returns {Promise<void>}
+     */
+    async function loadOidcConfig(oidcProvider) {
+        if (typeof oidcProvider === 'string') {
+            const url = `${stripTrailingSlash(oidcProvider)}/.well-known/openid-configuration`;
+            const openIdConfig = await fetchOpenIdConfig(url)
+            setupOidcEndpoints(openIdConfig);
+        } else {
+            setupOidcEndpoints(oidcProvider);
+        }
+    }
+
+    /**
+     * @returns {void}
+     */
+    function setupEndpoints() {
+        kc.endpoints = {
+            authorize() {
+                return getRealmUrl() + '/protocol/openid-connect/auth';
+            },
+            token() {
+                return getRealmUrl() + '/protocol/openid-connect/token';
+            },
+            logout() {
+                return getRealmUrl() + '/protocol/openid-connect/logout';
+            },
+            checkSessionIframe() {
+                return getRealmUrl() + '/protocol/openid-connect/login-status-iframe.html';
+            },
+            thirdPartyCookiesIframe() {
+                return getRealmUrl() + '/protocol/openid-connect/3p-cookies/step1.html';
+            },
+            register() {
+                return getRealmUrl() + '/protocol/openid-connect/registrations';
+            },
+            userinfo() {
+                return getRealmUrl() + '/protocol/openid-connect/userinfo';
+            }
+        };
+    }
+
+    /**
+     * @param {OpenIdProviderMetadata} config
+     * @returns {void}
+     */
+    function setupOidcEndpoints(config) {
+        kc.endpoints = {
+            authorize() {
+                return config.authorization_endpoint;
+            },
+            token() {
+                return config.token_endpoint;
+            },
+            logout() {
+                if (!config.end_session_endpoint) {
+                    throw "Not supported by the OIDC server";
+                }
+                return config.end_session_endpoint;
+            },
+            checkSessionIframe() {
+                if (!config.check_session_iframe) {
+                    throw "Not supported by the OIDC server";
+                }
+                return config.check_session_iframe;
+            },
+            register() {
+                throw 'Redirection to "Register user" page not supported in standard OIDC mode';
+            },
+            userinfo() {
+                if (!config.userinfo_endpoint) {
+                    throw "Not supported by the OIDC server";
+                }
+                return config.userinfo_endpoint;
+            }
+        }
     }
 
     function setToken(token, refreshToken, idToken, timeLocal) {
@@ -1050,26 +992,6 @@ function Keycloak (config) {
         return result;
     }
 
-    function createPromise() {
-        // Need to create a native Promise which also preserves the
-        // interface of the custom promise type previously used by the API
-        var p = {
-            setSuccess: function(result) {
-                p.resolve(result);
-            },
-
-            setError: function(result) {
-                p.reject(result);
-            }
-        };
-        p.promise = new Promise(function(resolve, reject) {
-            p.resolve = resolve;
-            p.reject = reject;
-        });
-
-        return p;
-    }
-
     // Function to extend existing native Promise with timeout
     function applyTimeoutToPromise(promise, timeout, errorMessage) {
         var timeoutHandle = null;
@@ -1084,41 +1006,27 @@ function Keycloak (config) {
         });
     }
 
-    function setupCheckLoginIframe() {
-        var promise = createPromise();
-
-        if (!loginIframe.enable) {
-            promise.setSuccess();
-            return promise.promise;
+    /**
+     * @returns {Promise<void>}
+     */
+    async function setupCheckLoginIframe() {
+        if (!loginIframe.enable || loginIframe.iframe) {
+            return
         }
 
-        if (loginIframe.iframe) {
-            promise.setSuccess();
-            return promise.promise;
-        }
-
-        var iframe = document.createElement('iframe');
+        const iframe = document.createElement('iframe');
         loginIframe.iframe = iframe;
-
-        iframe.onload = function() {
-            var authUrl = kc.endpoints.authorize();
-            if (authUrl.charAt(0) === '/') {
-                loginIframe.iframeOrigin = getOrigin();
-            } else {
-                loginIframe.iframeOrigin = authUrl.substring(0, authUrl.indexOf('/', 8));
-            }
-            promise.setSuccess();
-        }
-
-        var src = kc.endpoints.checkSessionIframe();
-        iframe.setAttribute('src', src );
+        iframe.setAttribute('src', kc.endpoints.checkSessionIframe());
         iframe.setAttribute('sandbox', 'allow-storage-access-by-user-activation allow-scripts allow-same-origin');
         iframe.setAttribute('title', 'keycloak-session-iframe' );
         iframe.style.display = 'none';
         document.body.appendChild(iframe);
 
-        var messageCallback = function(event) {
-            if ((event.origin !== loginIframe.iframeOrigin) || (loginIframe.iframe.contentWindow !== event.source)) {
+        /**
+         * @param {MessageEvent} event
+         */
+        const messageCallback = (event) => {
+            if (event.origin !== loginIframe.iframeOrigin || loginIframe.iframe.contentWindow !== event.source) {
                 return;
             }
 
@@ -1126,71 +1034,81 @@ function Keycloak (config) {
                 return;
             }
 
-
             if (event.data !== 'unchanged') {
                 kc.clearToken();
             }
 
-            var callbacks = loginIframe.callbackList.splice(0, loginIframe.callbackList.length);
+            const callbacks = loginIframe.callbackList;
+            loginIframe.callbackList = [];
 
-            for (var i = callbacks.length - 1; i >= 0; --i) {
-                var promise = callbacks[i];
+            for (const callback of callbacks.reverse()) {
                 if (event.data === 'error') {
-                    promise.setError();
+                    callback(new Error('Error while checking login iframe'));
                 } else {
-                    promise.setSuccess(event.data === 'unchanged');
+                    callback(null, event.data === 'unchanged');
                 }
             }
         };
 
         window.addEventListener('message', messageCallback, false);
 
-        return promise.promise;
+        await new Promise((resolve) => {
+            iframe.addEventListener('load', () => {
+                const authUrl = kc.endpoints.authorize();
+                if (authUrl.startsWith('/')) {
+                    loginIframe.iframeOrigin = location.origin;
+                } else {
+                    loginIframe.iframeOrigin = new URL(authUrl).origin;
+                }
+                resolve();
+            });
+        });
     }
 
-    function scheduleCheckIframe() {
-        if (loginIframe.enable) {
-            if (kc.token) {
-                setTimeout(function() {
-                    checkLoginIframe().then(function(unchanged) {
-                        if (unchanged) {
-                            scheduleCheckIframe();
-                        }
-                    });
-                }, loginIframe.interval * 1000);
+    async function scheduleCheckIframe() {
+        if (loginIframe.enable && kc.token) {
+            await waitForTimeout(loginIframe.interval * 1000);
+            const unchanged = await checkLoginIframe();
+
+            if (unchanged) {
+                await scheduleCheckIframe();
             }
         }
     }
 
-    function checkLoginIframe() {
-        var promise = createPromise();
+    async function checkLoginIframe() {
+        if (!loginIframe.iframe || !loginIframe.iframeOrigin) {
+            return;
+        }
 
-        if (loginIframe.iframe && loginIframe.iframeOrigin ) {
-            var msg = kc.clientId + ' ' + (kc.sessionId ? kc.sessionId : '');
-            loginIframe.callbackList.push(promise);
-            var origin = loginIframe.iframeOrigin;
+        const message = `${kc.clientId} ${(kc.sessionId ? kc.sessionId : '')}`;
+        const origin = loginIframe.iframeOrigin;
+
+        return await new Promise(function(resolve, reject) {
+            const callback = (error, result) => error ? reject(error) : resolve(result);
+
+            loginIframe.callbackList.push(callback);
+
             if (loginIframe.callbackList.length === 1) {
-                loginIframe.iframe.contentWindow.postMessage(msg, origin);
+                loginIframe.iframe.contentWindow.postMessage(message, origin);
             }
-        } else {
-            promise.setSuccess();
-        }
-
-        return promise.promise;
+        });
     }
 
-    function check3pCookiesSupported() {
-        var promise = createPromise();
+    async function check3pCookiesSupported() {
+        if ((!loginIframe.enable && !kc.silentCheckSsoRedirectUri) || typeof kc.endpoints.thirdPartyCookiesIframe !== 'function') {
+            return;
+        }
 
-        if ((loginIframe.enable || kc.silentCheckSsoRedirectUri) && typeof kc.endpoints.thirdPartyCookiesIframe === 'function') {
-            var iframe = document.createElement('iframe');
-            iframe.setAttribute('src', kc.endpoints.thirdPartyCookiesIframe());
-            iframe.setAttribute('sandbox', 'allow-storage-access-by-user-activation allow-scripts allow-same-origin');
-            iframe.setAttribute('title', 'keycloak-3p-check-iframe' );
-            iframe.style.display = 'none';
-            document.body.appendChild(iframe);
-
-            var messageCallback = function(event) {
+        const iframe = document.createElement('iframe');
+        iframe.setAttribute('src', kc.endpoints.thirdPartyCookiesIframe());
+        iframe.setAttribute('sandbox', 'allow-storage-access-by-user-activation allow-scripts allow-same-origin');
+        iframe.setAttribute('title', 'keycloak-3p-check-iframe' );
+        iframe.style.display = 'none';
+        document.body.appendChild(iframe);
+        
+        const promise = new Promise((resolve) => {
+            const messageCallback = (event) => {
                 if (iframe.contentWindow !== event.source) {
                     return;
                 }
@@ -1213,15 +1131,13 @@ function Keycloak (config) {
 
                 document.body.removeChild(iframe);
                 window.removeEventListener("message", messageCallback);
-                promise.setSuccess();
+                resolve();
             };
 
             window.addEventListener('message', messageCallback, false);
-        } else {
-            promise.setSuccess();
-        }
+        });
 
-        return applyTimeoutToPromise(promise.promise, kc.messageReceiveTimeout, "Timeout when waiting for 3rd party check iframe message.");
+        return await applyTimeoutToPromise(promise, kc.messageReceiveTimeout, "Timeout when waiting for 3rd party check iframe message.");
     }
 
     function loadAdapter(type) {
@@ -1229,7 +1145,7 @@ function Keycloak (config) {
             return {
                 login: async function(options) {
                     window.location.assign(await kc.createLoginUrl(options));
-                    return createPromise().promise;
+                    return await new Promise(() => {});
                 },
 
                 logout: async function(options) {
@@ -1271,17 +1187,17 @@ function Keycloak (config) {
 
                 register: async function(options) {
                     window.location.assign(await kc.createRegisterUrl(options));
-                    return createPromise().promise;
+                    return await new Promise(() => {});
                 },
 
-                accountManagement : function() {
+                accountManagement : async function() {
                     var accountUrl = kc.createAccountUrl();
                     if (typeof accountUrl !== 'undefined') {
                         window.location.href = accountUrl;
                     } else {
                         throw "Not supported by the OIDC server";
                     }
-                    return createPromise().promise;
+                    return await new Promise(() => {});
                 },
 
                 redirectUri: function(options) {
@@ -1333,69 +1249,75 @@ function Keycloak (config) {
             }
 
             return {
-                login: async function(options) {
-                    var promise = createPromise();
+                async login(options) {
+                    const cordovaOptions = createCordovaOptions(options);
+                    const loginUrl = await kc.createLoginUrl(options);
+                    const ref = cordovaOpenWindowWrapper(loginUrl, '_blank', cordovaOptions);
+                    let completed = false;
+                    let closed = false;
 
-                    var cordovaOptions = createCordovaOptions(options);
-                    var loginUrl = await kc.createLoginUrl(options);
-                    var ref = cordovaOpenWindowWrapper(loginUrl, '_blank', cordovaOptions);
-                    var completed = false;
-
-                    var closed = false;
-                    var closeBrowser = function() {
+                    function closeBrowser() {
                         closed = true;
                         ref.close();
                     };
 
-                    ref.addEventListener('loadstart', function(event) {
-                        if (event.url.indexOf(getCordovaRedirectUri()) === 0) {
-                            var callback = parseCallback(event.url);
-                            processCallback(callback, promise);
-                            closeBrowser();
-                            completed = true;
-                        }
-                    });
-
-                    ref.addEventListener('loaderror', function(event) {
-                        if (!completed) {
+                    return await new Promise((resolve, reject) => {
+                        ref.addEventListener('loadstart', async (event) => {
                             if (event.url.indexOf(getCordovaRedirectUri()) === 0) {
-                                var callback = parseCallback(event.url);
-                                processCallback(callback, promise);
+                                const callback = parseCallback(event.url);
+
+                                try {
+                                    await processCallback(callback);
+                                    resolve();
+                                } catch (error) {
+                                    reject(error);
+                                }
                                 closeBrowser();
                                 completed = true;
-                            } else {
-                                promise.setError();
-                                closeBrowser();
                             }
-                        }
-                    });
+                        });
 
-                    ref.addEventListener('exit', function(event) {
-                        if (!closed) {
-                            promise.setError({
-                                reason: "closed_by_user"
-                            });
-                        }
-                    });
+                        ref.addEventListener('loaderror', async (event) => {
+                            if (!completed) {
+                                if (event.url.indexOf(getCordovaRedirectUri()) === 0) {
+                                    const callback = parseCallback(event.url);
+                                    try {
+                                        await processCallback(callback);
+                                        resolve();
+                                    } catch (error) {
+                                        reject(error);
+                                    }
+                                    closeBrowser();
+                                    completed = true;
+                                } else {
+                                    reject();
+                                    closeBrowser();
+                                }
+                            }
+                        });
 
-                    return promise.promise;
+                        ref.addEventListener('exit', function(event) {
+                            if (!closed) {
+                                reject({
+                                    reason: "closed_by_user"
+                                });
+                            }
+                        });
+                    });
                 },
 
-                logout: function(options) {
-                    var promise = createPromise();
+                async logout(options) {
+                    const logoutUrl = kc.createLogoutUrl(options);
+                    const ref = cordovaOpenWindowWrapper(logoutUrl, '_blank', 'location=no,hidden=yes,clearcache=yes');
+                    let error = false;
 
-                    var logoutUrl = kc.createLogoutUrl(options);
-                    var ref = cordovaOpenWindowWrapper(logoutUrl, '_blank', 'location=no,hidden=yes,clearcache=yes');
-
-                    var error;
-
-                    ref.addEventListener('loadstart', function(event) {
+                    ref.addEventListener('loadstart', (event) => {
                         if (event.url.indexOf(getCordovaRedirectUri()) === 0) {
                             ref.close();
                         }
                     });
 
-                    ref.addEventListener('loaderror', function(event) {
+                    ref.addEventListener('loaderror', (event) => {
                         if (event.url.indexOf(getCordovaRedirectUri()) === 0) {
                             ref.close();
                         } else {
@@ -1404,31 +1326,38 @@ function Keycloak (config) {
                         }
                     });
 
-                    ref.addEventListener('exit', function(event) {
-                        if (error) {
-                            promise.setError();
-                        } else {
-                            kc.clearToken();
-                            promise.setSuccess();
-                        }
+                    await new Promise((resolve, reject) => {
+                        ref.addEventListener('exit', () => {
+                            if (error) {
+                                reject();
+                            } else {
+                                kc.clearToken();
+                                resolve();
+                            }
+                        });
                     });
-
-                    return promise.promise;
                 },
 
-                register : async function(options) {
-                    var promise = createPromise();
-                    var registerUrl = await kc.createRegisterUrl();
-                    var cordovaOptions = createCordovaOptions(options);
-                    var ref = cordovaOpenWindowWrapper(registerUrl, '_blank', cordovaOptions);
-                    ref.addEventListener('loadstart', function(event) {
-                        if (event.url.indexOf(getCordovaRedirectUri()) === 0) {
-                            ref.close();
-                            var oauth = parseCallback(event.url);
-                            processCallback(oauth, promise);
-                        }
+                async register(options) {
+                    const registerUrl = await kc.createRegisterUrl();
+                    const cordovaOptions = createCordovaOptions(options);
+                    const ref = cordovaOpenWindowWrapper(registerUrl, '_blank', cordovaOptions);
+
+                    await new Promise((resolve, reject) => {
+                        ref.addEventListener('loadstart', async (event) => {
+                            if (event.url.indexOf(getCordovaRedirectUri()) === 0) {
+                                ref.close();
+                                const oauth = parseCallback(event.url);
+
+                                try {
+                                    await processCallback(oauth);
+                                    resolve();
+                                } catch (error) {
+                                    reject(error);
+                                }
+                            }
+                        });
                     });
-                    return promise.promise;
                 },
 
                 accountManagement : function() {
@@ -1455,48 +1384,60 @@ function Keycloak (config) {
             loginIframe.enable = false;
 
             return {
-                login: async function(options) {
-                    var promise = createPromise();
-                    var loginUrl = await kc.createLoginUrl(options);
+                async login(options) {
+                    const loginUrl = await kc.createLoginUrl(options);
 
-                    universalLinks.subscribe('keycloak', function(event) {
-                        universalLinks.unsubscribe('keycloak');
-                        window.cordova.plugins.browsertab.close();
-                        var oauth = parseCallback(event.url);
-                        processCallback(oauth, promise);
+                    await new Promise((resolve, reject) => {
+                        universalLinks.subscribe('keycloak', async (event) => {
+                            universalLinks.unsubscribe('keycloak');
+                            window.cordova.plugins.browsertab.close();
+                            var oauth = parseCallback(event.url);
+                            
+                            try {
+                                await processCallback(oauth);
+                                resolve();
+                            } catch (error) {
+                                reject(error);
+                            }
+                        });
+    
+                        window.cordova.plugins.browsertab.openUrl(loginUrl);
                     });
-
-                    window.cordova.plugins.browsertab.openUrl(loginUrl);
-                    return promise.promise;
                 },
 
-                logout: function(options) {
-                    var promise = createPromise();
-                    var logoutUrl = kc.createLogoutUrl(options);
+                async logout(options) {
+                    const logoutUrl = kc.createLogoutUrl(options);
 
-                    universalLinks.subscribe('keycloak', function(event) {
-                        universalLinks.unsubscribe('keycloak');
-                        window.cordova.plugins.browsertab.close();
-                        kc.clearToken();
-                        promise.setSuccess();
+                    await new Promise((resolve) => {
+                        universalLinks.subscribe('keycloak', () => {
+                            universalLinks.unsubscribe('keycloak');
+                            window.cordova.plugins.browsertab.close();
+                            kc.clearToken();
+                            resolve();
+                        });
+    
+                        window.cordova.plugins.browsertab.openUrl(logoutUrl);
                     });
-
-                    window.cordova.plugins.browsertab.openUrl(logoutUrl);
-                    return promise.promise;
                 },
 
-                register : async function(options) {
-                    var promise = createPromise();
-                    var registerUrl = await kc.createRegisterUrl(options);
-                    universalLinks.subscribe('keycloak' , function(event) {
-                        universalLinks.unsubscribe('keycloak');
-                        window.cordova.plugins.browsertab.close();
-                        var oauth = parseCallback(event.url);
-                        processCallback(oauth, promise);
-                    });
-                    window.cordova.plugins.browsertab.openUrl(registerUrl);
-                    return promise.promise;
+                async register(options) {
+                    const registerUrl = await kc.createRegisterUrl(options);
 
+                    await new Promise((resolve, reject) => {
+                        universalLinks.subscribe('keycloak' , async (event) => {
+                            universalLinks.unsubscribe('keycloak');
+                            window.cordova.plugins.browsertab.close();
+                            const oauth = parseCallback(event.url);
+                            try {
+                                await processCallback(oauth);
+                                resolve();
+                            } catch (error) {
+                                reject(error);
+                            }
+                        });
+
+                        window.cordova.plugins.browsertab.openUrl(registerUrl);
+                    });
                 },
 
                 accountManagement : function() {
@@ -1941,6 +1882,14 @@ function buildAuthorizationHeader(token) {
 }
 
 /**
+ * @param {string} url 
+ * @returns {string}
+ */
+function stripTrailingSlash(url) {
+    return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+/**
  * @typedef {Object} NetworkErrorOptionsProperties
  * @property {Response} response
  * @typedef {ErrorOptions & NetworkErrorOptionsProperties} NetworkErrorOptions
@@ -1959,3 +1908,9 @@ export class NetworkError extends Error {
         this.response = options.response;
     }
 }
+
+/**
+ * @param {number} delay 
+ * @returns {Promise<void>}
+ */
+const waitForTimeout = (delay) => new Promise((resolve) => setTimeout(resolve, delay));

--- a/test/tests/account-url.spec.ts
+++ b/test/tests/account-url.spec.ts
@@ -31,5 +31,5 @@ test('throws creating an account URL using a generic OpenID provider', async ({ 
     oidcProvider: oidcProviderUrl.toString()
   })
   await executor.initializeAdapter(executor.defaultInitOptions())
-  await expect(executor.createAccountUrl()).rejects.toThrow('Unable to create account URL, make sure the adapter not is configured using a generic OIDC provider.')
+  await expect(executor.createAccountUrl()).rejects.toThrow('Unable to create account URL, make sure the adapter is not configured using a generic OIDC provider.')
 })

--- a/test/tests/token.spec.ts
+++ b/test/tests/token.spec.ts
@@ -1,12 +1,26 @@
 import { expect } from '@playwright/test'
 import { createTestBed, test } from '../support/testbed.ts'
+import type { KeycloakInitOptions } from '../../lib/keycloak.js'
 
 test('refreshes a token', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions = executor.defaultInitOptions()
   // Initially, no user should be authenticated and refreshing the token should fail.
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
-  await expect(executor.updateToken(9999)).rejects.toThrow()
+  await expect(executor.updateToken(9999)).rejects.toThrow('Unable to update token, no refresh token available.')
+  await executor.login()
+  await executor.submitLoginForm()
+  // After triggering a login, the user should be authenticated and refreshing the token should succeed.
+  expect(await executor.initializeAdapter(initOptions)).toBe(true)
+  expect(await executor.updateToken(9999)).toBe(true)
+})
+
+test('refreshes a token with login iframe disabled', async ({ page, appUrl, authServerUrl }) => {
+  const { executor } = await createTestBed(page, { appUrl, authServerUrl })
+  const initOptions: KeycloakInitOptions = { ...executor.defaultInitOptions(), checkLoginIframe: false }
+  // Initially, no user should be authenticated and refreshing the token should fail.
+  expect(await executor.initializeAdapter(initOptions)).toBe(false)
+  await expect(executor.updateToken(9999)).rejects.toThrow('Unable to update token, no refresh token available.')
   await executor.login()
   await executor.submitLoginForm()
   // After triggering a login, the user should be authenticated and refreshing the token should succeed.

--- a/test/tests/user-profile.spec.ts
+++ b/test/tests/user-profile.spec.ts
@@ -31,5 +31,5 @@ test('throws loading the user profile using a generic OpenID provider', async ({
   await executor.submitLoginForm()
   await executor.instantiateAdapter(configOptions)
   await executor.initializeAdapter(initOptions)
-  await expect(executor.loadUserProfile()).rejects.toThrow('Unable to load user profile, make sure the adapter not is configured using a generic OIDC provider.')
+  await expect(executor.loadUserProfile()).rejects.toThrow('Unable to load user profile, make sure the adapter is not configured using a generic OIDC provider.')
 })


### PR DESCRIPTION
Removes the custom internal `createPromise()` implementation, which is a remnant of the old custom promises that Keycloak JS used to use. This replaces all the internals with the standard Promise API, and untangles a bunch of spaghetti code caused by callbacks by replacing them with `async` functions and `await`ing them.

Closes #88