### PR TITLE
Use built-in APIs to parse URLs

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -804,8 +804,8 @@ export default class Keycloak {
     async #processInit(initOptions) {
         const callback = this.#parseCallback(window.location.href);
 
-        if (callback) {
-            window.history.replaceState(window.history.state, '', /** @type {string} */ (callback.newUrl));
+        if (callback?.redirectUri) {
+            window.history.replaceState(window.history.state, '', callback.redirectUri);
         }
 
         if (callback && callback.valid) {
@@ -1032,10 +1032,10 @@ export default class Keycloak {
     }
 
     /**
-     * @param {string} url
+     * @param {string} urlString
      */
-    #parseCallbackUrl(url) {
-        var supportedParams;
+    #parseCallbackUrl(urlString) {
+        let supportedParams = [];
         switch (this.flow) {
             case 'standard':
                 supportedParams = ['code', 'state', 'session_state', 'kc_action_status', 'kc_action', 'iss'];
@@ -1052,38 +1052,29 @@ export default class Keycloak {
         supportedParams.push('error_description');
         supportedParams.push('error_uri');
 
-        var queryIndex = url.indexOf('?');
-        var fragmentIndex = url.indexOf('#');
+        const url = new URL(urlString);
+        let redirectUri = '';
+        let parsed;
 
-        var newUrl = '';
-        var parsed;
-
-        if (this.responseMode === 'query' && queryIndex !== -1) {
-            newUrl = url.substring(0, queryIndex);
-            parsed = this.#parseCallbackParams(url.substring(queryIndex + 1, fragmentIndex !== -1 ? fragmentIndex : url.length), supportedParams);
-            if (parsed.paramsString !== '') {
-                newUrl += '?' + parsed.paramsString;
-            }
-            if (fragmentIndex !== -1) {
-                newUrl += url.substring(fragmentIndex);
-            }
-        } else if (this.responseMode === 'fragment' && fragmentIndex !== -1) {
-            newUrl = url.substring(0, fragmentIndex);
-            parsed = this.#parseCallbackParams(url.substring(fragmentIndex + 1), supportedParams);
-            if (parsed.paramsString !== '') {
-                newUrl += '#' + parsed.paramsString;
-            }
+        if (this.responseMode === 'query' && url.searchParams.size > 0) {
+            parsed = this.#parseCallbackParams(url.search, supportedParams);
+            url.search = parsed.paramsString;
+            redirectUri = url.toString();
+        } else if (this.responseMode === 'fragment' && url.hash.length > 0) {
+            parsed = this.#parseCallbackParams(url.hash.substring(1), supportedParams);
+            url.hash = '';
+            redirectUri = url.toString();
         }
 
-        if (parsed && parsed.oauthParams) {
+        if (parsed?.oauthParams) {
             if (this.flow === 'standard' || this.flow === 'hybrid') {
                 if ((parsed.oauthParams.code || parsed.oauthParams.error) && parsed.oauthParams.state) {
-                    parsed.oauthParams.newUrl = newUrl;
+                    parsed.oauthParams.redirectUri = redirectUri;
                     return parsed.oauthParams;
                 }
             } else if (this.flow === 'implicit') {
                 if ((parsed.oauthParams.access_token || parsed.oauthParams.error) && parsed.oauthParams.state) {
-                    parsed.oauthParams.newUrl = newUrl;
+                    parsed.oauthParams.redirectUri = redirectUri;
                     return parsed.oauthParams;
                 }
             }
@@ -1102,26 +1093,21 @@ export default class Keycloak {
      * @returns {ParsedCallbackParams}
      */
     #parseCallbackParams(paramsString, supportedParams) {
-        var p = paramsString.split('&');
+        const params = new URLSearchParams(paramsString);
+        /** @type {Record<string, string>} */
+        const oauthParams = {};
 
-        /** @type {ParsedCallbackParams} */
-        var result = {
-            paramsString: '',
-            oauthParams: {}
-        }
-        for (var i = 0; i < p.length; i++) {
-            var split = p[i].indexOf("=");
-            var key = p[i].slice(0, split);
-            if (supportedParams.indexOf(key) !== -1) {
-                result.oauthParams[key] = p[i].slice(split + 1);
-            } else {
-                if (result.paramsString !== '') {
-                    result.paramsString += '&';
-                }
-                result.paramsString += p[i];
+        for (const [key, value] of Array.from(params.entries())) {
+            if (supportedParams.includes(key)) {
+                oauthParams[key] = value;
+                params.delete(key);
             }
         }
-        return result;
+
+        return {
+            paramsString: params.toString(),
+            oauthParams
+        };
     }
 
     async #processCallback(oauth) {
@@ -1167,7 +1153,7 @@ export default class Keycloak {
 
         if ((this.flow !== 'implicit') && code) {
             try {
-                const response = await fetchAccessToken(this.endpoints.token(), code, /** @type {string} */ (this.clientId), decodeURIComponent(oauth.redirectUri), oauth.pkceCodeVerifier)
+                const response = await fetchAccessToken(this.endpoints.token(), code, /** @type {string} */ (this.clientId), oauth.redirectUri, oauth.pkceCodeVerifier)
                 authSuccess(response['access_token'], response['refresh_token'], response['id_token']);
 
                 if (this.flow === 'standard') {
@@ -1213,7 +1199,7 @@ export default class Keycloak {
         const callbackState = {
             state,
             nonce,
-            redirectUri: encodeURIComponent(redirectUri),
+            redirectUri,
             loginOptions: options
         };
 
@@ -1237,7 +1223,9 @@ export default class Keycloak {
 
         const params = new URLSearchParams([
             ['client_id', /** @type {string} */ (this.clientId)],
-            ['redirect_uri', redirectUri],
+            // The endpoint URI MUST NOT include a fragment component.
+            // https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2
+            ['redirect_uri', stripHash(redirectUri)],
             ['state', state],
             ['response_mode', this.responseMode],
             ['response_type', this.responseType],
@@ -2083,7 +2071,7 @@ async function fetchAccessToken(url, code, clientId, redirectUri, pkceCodeVerifi
         ['code', code],
         ['grant_type', 'authorization_code'],
         ['client_id', clientId],
-        ['redirect_uri', redirectUri]
+        ['redirect_uri', stripHash(redirectUri)]
     ]);
 
     if (pkceCodeVerifier) {
@@ -2169,6 +2157,16 @@ function buildAuthorizationHeader(token) {
  */
 function stripTrailingSlash(url) {
     return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+/**
+ * @param {string} url 
+ * @returns {string}
+ */
+function stripHash(url) {
+    const parsedUrl = new URL(url);
+    parsedUrl.hash = '';
+    return parsedUrl.toString();
 }
 
 /**

--- a/test/tests/implicit-flow.spec.ts
+++ b/test/tests/implicit-flow.spec.ts
@@ -11,7 +11,7 @@ test('logs in with an implicit flow', async ({ page, appUrl, authServerUrl }) =>
   await executor.login()
   await expect(executor.initializeAdapter(implicitFlow)).rejects.toMatchObject({
     error: 'unauthorized_client',
-    error_description: 'Client+is+not+allowed+to+initiate+browser+login+with+given+response_type.+Implicit+flow+is+disabled+for+the+client.'
+    error_description: 'Client is not allowed to initiate browser login with given response_type. Implicit flow is disabled for the client.'
   })
   // After enabling implicit flow, authenticating with the standard flow should fail.
   await updateClient({ implicitFlowEnabled: true, standardFlowEnabled: false })
@@ -20,7 +20,7 @@ test('logs in with an implicit flow', async ({ page, appUrl, authServerUrl }) =>
   await executor.login()
   await expect(executor.initializeAdapter(standardFlow)).rejects.toMatchObject({
     error: 'unauthorized_client',
-    error_description: 'Client+is+not+allowed+to+initiate+browser+login+with+given+response_type.+Standard+flow+is+disabled+for+the+client.'
+    error_description: 'Client is not allowed to initiate browser login with given response_type. Standard flow is disabled for the client.'
   })
   // Now that the implicit flow is enabled, the user should be able to authenticate successfully.
   await executor.reload()
@@ -44,7 +44,7 @@ test('does not allow query response mode with an implicit flow', async ({ page, 
   await executor.login()
   await expect(executor.initializeAdapter(initOptions)).rejects.toMatchObject({
     error: 'invalid_request',
-    error_description: 'Response_mode+%27query%27+not+allowed+for+implicit+or+hybrid+flow'
+    error_description: "Response_mode 'query' not allowed for implicit or hybrid flow"
   })
 })
 


### PR DESCRIPTION
Re-writes the callback URL parsing to use standard APIs such as `URLSearchParams`. This also fixes a bug where some data would be double encoded, as well as improving spec compliance by omitting the hash from the redirect URI.

Closes #56