### PR TITLE
Support non-JWT refresh tokens in Keycloak.

### DIFF
--- a/lib/keycloak.d.ts
+++ b/lib/keycloak.d.ts
@@ -219,6 +219,12 @@ export interface KeycloakInitOptions {
 	messageReceiveTimeout?: number
 
 	/**
+	 * Configures whether the adapter should include the refresh token in the JWT.
+	 * @default true
+	 */
+	refreshTokenIsJWT?: boolean
+
+	/**
 	 * When onLoad is 'login-required', sets the 'ui_locales' query param in compliance with section 3.1.2.1
 	 * of the OIDC 1.0 specification.
 	 */

--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -85,6 +85,8 @@ export default class Keycloak {
     /** @type {string=} */
     scope;
     messageReceiveTimeout = 10000;
+    /** @type {boolean=} */
+    refreshTokenIsJWT;
     /** @type {string=} */
     idToken;
     /** @type {KeycloakTokenParsed=} */
@@ -270,6 +272,12 @@ export default class Keycloak {
 
         if (typeof initOptions.messageReceiveTimeout === 'number' && initOptions.messageReceiveTimeout > 0) {
             this.messageReceiveTimeout = initOptions.messageReceiveTimeout;
+        }
+
+        if (typeof initOptions.refreshTokenIsJWT === 'boolean') {
+            this.refreshTokenIsJWT = initOptions.refreshTokenIsJWT;
+        } else {
+            this.refreshTokenIsJWT = true;
         }
 
         await this.#loadConfig();
@@ -1535,7 +1543,9 @@ export default class Keycloak {
 
         if (refreshToken) {
             this.refreshToken = refreshToken;
-            this.refreshTokenParsed = decodeToken(refreshToken);
+            if (this.refreshTokenIsJWT === true) {
+              this.refreshTokenParsed = decodeToken(refreshToken);
+            }
         } else {
             delete this.refreshToken;
             delete this.refreshTokenParsed;


### PR DESCRIPTION
While the Keycloak Server does issue refresh tokens with JWT payload, many other OIDC servers do not, and the OIDC spec does not require this. And currently Keycloak always tries to parse refresh token as JWT, which breaks login flow for such servers.

Closes #149