### PR TITLE
Support url paraeter forwarding in keycloak-js.

### DIFF
--- a/lib/keycloak.d.ts
+++ b/lib/keycloak.d.ts
@@ -228,6 +228,13 @@ export interface KeycloakInitOptions {
 	 * HTTP method for calling the end_session endpoint. Defaults to 'GET'.
 	 */
 	logoutMethod?: 'GET' | 'POST';
+
+	/**
+	 * Configures url parameters to forward to Keycloak server.
+	 * These are specified as an object with key-value pairs.
+	 * Note that the keys need to be enabled in the Keycloak server in the 'Forwarded parameters' section.
+	 */
+	forwardParameters?: { [key: string]: string };
 }
 
 export interface KeycloakLoginOptions {
@@ -294,6 +301,13 @@ export interface KeycloakLoginOptions {
 	 * of the OIDC 1.0 specification.
 	 */
 	locale?: string;
+
+	/**
+	 * Configures url parameters to forward to Keycloak server.
+	 * These are specified as an object with key-value pairs.
+	 * Note that the keys need to be enabled in the Keycloak server in the 'Forwarded parameters' section.
+	 */
+	forwardParameters?: { [key: string]: string };
 
 	/**
 	 * Specifies arguments that are passed to the Cordova in-app-browser (if applicable).

--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -80,6 +80,8 @@ export default class Keycloak {
     /** @type {KeycloakPkceMethod} */
     pkceMethod = 'S256';
     enableLogging = false;
+    /** @type {{ [key: string]: string }=} */
+    forwardParameters;
     /** @type {'GET' | 'POST'} */
     logoutMethod = 'GET';
     /** @type {string=} */
@@ -266,6 +268,10 @@ export default class Keycloak {
 
         if (typeof initOptions.scope === 'string') {
             this.scope = initOptions.scope;
+        }
+
+        if (initOptions.forwardParameters) {
+            this.forwardParameters = initOptions.forwardParameters;
         }
 
         if (typeof initOptions.messageReceiveTimeout === 'number' && initOptions.messageReceiveTimeout > 0) {
@@ -1266,6 +1272,13 @@ export default class Keycloak {
 
         if (options?.acrValues) {
             params.append('acr_values', options.acrValues);
+        }
+
+        if (options?.forwardParameters) {
+            const forwardParameters = options.forwardParameters;
+            Object.keys(forwardParameters).forEach(function (key) {
+                params.append(key, forwardParameters[key]);
+            });
         }
 
         if (this.pkceMethod) {


### PR DESCRIPTION
This revision adds an optional init attribute 'forwardParameters', that can contain key/value pairs to include (forward) in any calls to the server.

Closes keycloak#150