### PR TITLE
Ensure that stripHash() function does not add a trailing slash.

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -2164,9 +2164,8 @@ function stripTrailingSlash(url) {
  * @returns {string}
  */
 function stripHash(url) {
-    const parsedUrl = new URL(url);
-    parsedUrl.hash = '';
-    return parsedUrl.toString();
+    // Important not to add any extra trailing slashes here, so we use a regex.
+    return url.replace(/#.*$/, '');
 }
 
 /**


### PR DESCRIPTION
This is important, as adding trailing slashes can break the redirectUri.

Closes #151