### PR TITLE
Bind public methods to class instance

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -172,7 +172,7 @@ export default class Keycloak {
    * @param {KeycloakInitOptions} initOptions
    * @returns {Promise<boolean>}
    */
-  async init (initOptions = {}) {
+  init = async (initOptions = {}) => {
     if (this.didInitialize) {
       throw new Error("A 'Keycloak' instance can only be initialized once.")
     }
@@ -1180,7 +1180,7 @@ export default class Keycloak {
    * @param {KeycloakLoginOptions} [options]
    * @returns {Promise<void>}
    */
-  login (options) {
+  login = (options) => {
     return this.#adapter.login(options)
   }
 
@@ -1188,7 +1188,7 @@ export default class Keycloak {
    * @param {KeycloakLoginOptions} [options]
    * @returns {Promise<string>}
    */
-  async createLoginUrl (options) {
+  createLoginUrl = async (options) => {
     const state = createUUID()
     const nonce = createUUID()
     const redirectUri = this.#adapter.redirectUri(options)
@@ -1288,7 +1288,7 @@ export default class Keycloak {
    * @param {KeycloakLogoutOptions} [options]
    * @returns {Promise<void>}
    */
-  logout (options) {
+  logout = (options) => {
     return this.#adapter.logout(options)
   }
 
@@ -1296,7 +1296,7 @@ export default class Keycloak {
    * @param {KeycloakLogoutOptions} [options]
    * @returns {string}
    */
-  createLogoutUrl (options) {
+  createLogoutUrl = (options) => {
     const logoutMethod = options?.logoutMethod ?? this.logoutMethod
     const url = this.endpoints.logout()
 
@@ -1320,7 +1320,7 @@ export default class Keycloak {
    * @param {KeycloakRegisterOptions} [options]
    * @returns {Promise<void>}
    */
-  register (options) {
+  register = (options) => {
     return this.#adapter.register(options)
   }
 
@@ -1328,7 +1328,7 @@ export default class Keycloak {
    * @param {KeycloakRegisterOptions} [options]
    * @returns {Promise<string>}
    */
-  createRegisterUrl (options) {
+  createRegisterUrl = (options) => {
     return this.createLoginUrl({ ...options, action: 'register' })
   }
 
@@ -1336,7 +1336,7 @@ export default class Keycloak {
    * @param {KeycloakAccountOptions} [options]
    * @returns {string}
    */
-  createAccountUrl (options) {
+  createAccountUrl = (options) => {
     const url = this.#getRealmUrl()
 
     if (!url) {
@@ -1354,7 +1354,7 @@ export default class Keycloak {
   /**
    * @returns {Promise<void>}
    */
-  accountManagement () {
+  accountManagement = () => {
     return this.#adapter.accountManagement()
   }
 
@@ -1362,7 +1362,7 @@ export default class Keycloak {
    * @param {string} role
    * @returns {boolean}
    */
-  hasRealmRole (role) {
+  hasRealmRole = (role) => {
     const access = this.realmAccess
     return !!access && access.roles.indexOf(role) >= 0
   }
@@ -1372,7 +1372,7 @@ export default class Keycloak {
    * @param {string} [resource]
    * @returns {boolean}
    */
-  hasResourceRole (role, resource) {
+  hasResourceRole = (role, resource) => {
     if (!this.resourceAccess) {
       return false
     }
@@ -1384,7 +1384,7 @@ export default class Keycloak {
   /**
    * @returns {Promise<KeycloakProfile>}
    */
-  async loadUserProfile () {
+  loadUserProfile = async () => {
     const realmUrl = this.#getRealmUrl()
 
     if (!realmUrl) {
@@ -1403,7 +1403,7 @@ export default class Keycloak {
   /**
    * @returns {Promise<{}>}
    */
-  async loadUserInfo () {
+  loadUserInfo = async () => {
     const url = this.endpoints.userinfo()
     /** @type {{}} */
     const userInfo = await fetchJSON(url, {
@@ -1417,7 +1417,7 @@ export default class Keycloak {
    * @param {number} [minValidity]
    * @returns {boolean}
    */
-  isTokenExpired (minValidity) {
+  isTokenExpired = (minValidity) => {
     if (!this.tokenParsed || (!this.refreshToken && this.flow !== 'implicit')) {
       throw new Error('Not authenticated')
     }
@@ -1445,7 +1445,7 @@ export default class Keycloak {
    * @param {number} minValidity
    * @returns {Promise<boolean>}
    */
-  async updateToken (minValidity) {
+  updateToken = async (minValidity) => {
     if (!this.refreshToken) {
       throw new Error('Unable to update token, no refresh token available.')
     }
@@ -1508,7 +1508,7 @@ export default class Keycloak {
     return await promise
   }
 
-  clearToken () {
+  clearToken = () => {
     if (this.token) {
       this.#setToken()
       this.onAuthLogout?.()


### PR DESCRIPTION
Binds all public methods directly to the Keycloak instance using arrow function to prevent scoping issues. Although this would prevent binding public methods, which users might rely on (as a hack, nothing officially supported), this re-enables a much more widespread and common use-case to destructuring methods:

```js
const { login } = new Keycloak();
```

Closes #202