### PR TITLE
Expose process callback url function

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -1165,6 +1165,20 @@ export default class Keycloak {
     }
   }
 
+  /**
+   * @param {string} url
+   * @returns {Promise<void>}
+   */
+  processCallbackUrl = async (url) => {
+    const callback = this.#parseCallback(url)
+    
+    if (callback && callback.valid) {
+      await this.#processCallback(callback)
+    } else {
+      throw new Error('Invalid callback URL.')
+    }
+  }
+
   async #scheduleCheckIframe () {
     if (this.#loginIframe.enable && this.token) {
       await waitForTimeout(this.#loginIframe.interval * 1000)


### PR DESCRIPTION
@luchsamapparat outlined in [this issue](https://github.com/keycloak/keycloak-js/issues/27) why it is currently cumbersome to create a custom adapter for keycloak-js.

This PR adds a single simple method to ease custom adapter creation, since no logic from keycloak-js would need to be replicated in the adapter anymore (ensuring both `createLoginUrl` and `processCallbackUrl` access the same `#callbackStorage`).

Creating a custom adapter could become as simple as 

```
export class MobileKeycloakAdapter implements KeycloakAdapter {

    constructor(keycloak: Keycloak)
...
    login = async (options?: KeycloakLoginOptions): Promise<void> => {
       const loginUrl = await this.forkedKeycloak.createLoginUrl(options);
       await this.openUrlInSecureBrowserAndListenForCallback(url).then(callbackUrl => {
           this.keycloak.processCallbackUrl(callbackUrl);
       });
    };
...
}
```

#### Considerations

In our fork that we currently use to create the custom adapter, we are doing something like this

```
this.forkedKeycloak.processCallback(this.forkedKeycloak.parseCallback(event.url));
```

but exposing both methods would leak the `oauth` object publicly and trying to type it was not easy. Since for our case (and maybe for most cases?) we only cared about the callback being fully parsed and the tokens being set correctly, we thought it might be better to expose a single method.

With this approach the adapter would only need to worry about one thing - opening the login url and receiving the callback.