### PR TITLE
Pass URL without trailing slashes to admin client

### DIFF
--- a/test/support/admin-client.ts
+++ b/test/support/admin-client.ts
@@ -1,9 +1,12 @@
 import AdminClient from '@keycloak/keycloak-admin-client'
 import { ADMIN_PASSWORD, ADMIN_USERNAME, AUTH_SERVER_URL } from './common.ts'
 
-export const adminClient = new AdminClient({
-  baseUrl: AUTH_SERVER_URL.toString()
-})
+// Trailing slashes can cause issues with requests from the Admin Client.
+// See: https://github.com/keycloak/keycloak/issues/44269
+const authServerUrl = AUTH_SERVER_URL.toString()
+const baseUrl = authServerUrl.endsWith('/') ? authServerUrl.slice(0, -1) : authServerUrl
+
+export const adminClient = new AdminClient({ baseUrl })
 
 await adminClient.auth({
   username: ADMIN_USERNAME,


### PR DESCRIPTION
Removes the trailing slash from URLs passed into the admin client used by the test suite, this prevents issues where the trailing slash can be duplicated in the request, causing failures.

Closes #217