### PR TITLE
Do not strip hash from redirection endpoint

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -1220,9 +1220,7 @@ export default class Keycloak {
 
     const params = new URLSearchParams([
       ['client_id', /** @type {string} */ (this.clientId)],
-      // The endpoint URI MUST NOT include a fragment component.
-      // https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2
-      ['redirect_uri', stripHash(redirectUri)],
+      ['redirect_uri', redirectUri],
       ['state', state],
       ['response_mode', this.responseMode],
       ['response_type', this.responseType],
@@ -2067,7 +2065,7 @@ async function fetchAccessToken (url, code, clientId, redirectUri, pkceCodeVerif
     ['code', code],
     ['grant_type', 'authorization_code'],
     ['client_id', clientId],
-    ['redirect_uri', stripHash(redirectUri)]
+    ['redirect_uri', redirectUri]
   ])
 
   if (pkceCodeVerifier) {
@@ -2153,16 +2151,6 @@ function buildAuthorizationHeader (token) {
  */
 function stripTrailingSlash (url) {
   return url.endsWith('/') ? url.slice(0, -1) : url
-}
-
-/**
- * @param {string} url
- * @returns {string}
- */
-function stripHash (url) {
-  const parsedUrl = new URL(url)
-  parsedUrl.hash = ''
-  return parsedUrl.toString()
 }
 
 /**

--- a/test/tests/preserves-fragment.spec.ts
+++ b/test/tests/preserves-fragment.spec.ts
@@ -1,0 +1,28 @@
+import { expect } from '@playwright/test'
+import { createTestBed, test } from '../support/testbed.ts'
+
+test('preserves URL fragment after login and logout', async ({ page, appUrl, authServerUrl }) => {
+  const { executor } = await createTestBed(page, { appUrl, authServerUrl })
+  const initOptions = executor.defaultInitOptions()
+  const fragment = '#section=preserved'
+  const appUrlWithFragment = new URL(appUrl)
+
+  appUrlWithFragment.hash = fragment
+
+  // Navigate to the application URL with a fragment.
+  await page.goto(appUrlWithFragment.toString())
+
+  // Initialize the adapter and perform login.
+  await executor.initializeAdapter(initOptions)
+  await executor.login()
+  await executor.submitLoginForm()
+
+  // After login and adapter initialization, the URL fragment should be preserved.
+  await executor.initializeAdapter(initOptions)
+  expect(new URL(await page.url()).hash).toBe(fragment)
+
+  // After logout, the URL fragment should still be preserved.
+  await executor.logout()
+  await executor.initializeAdapter(initOptions)
+  expect(new URL(await page.url()).hash).toBe(fragment)
+})


### PR DESCRIPTION
Removes the behavior that strips the hashes from the redirection endpoint URLs. Although this behavior is not standard compliant, it fixes several regressions in instances where users rely on this non-standard behavior.

Closes #151
Closes #205