### PR TITLE
Allow redirect URL to be different than app origin

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -802,8 +802,8 @@ export default class Keycloak {
   async #processInit (initOptions) {
     const callback = this.#parseCallback(window.location.href)
 
-    if (callback?.redirectUri) {
-      window.history.replaceState(window.history.state, '', callback.redirectUri)
+    if (callback?.newUrl) {
+      window.history.replaceState(window.history.state, '', callback.newUrl)
     }
 
     if (callback && callback.valid) {
@@ -1050,28 +1050,28 @@ export default class Keycloak {
     supportedParams.push('error_uri')
 
     const url = new URL(urlString)
-    let redirectUri = ''
+    let newUrl = ''
     let parsed
 
     if (this.responseMode === 'query' && url.searchParams.size > 0) {
       parsed = this.#parseCallbackParams(url.search, supportedParams)
       url.search = parsed.paramsString
-      redirectUri = url.toString()
+      newUrl = url.toString()
     } else if (this.responseMode === 'fragment' && url.hash.length > 0) {
       parsed = this.#parseCallbackParams(url.hash.substring(1), supportedParams)
-      url.hash = ''
-      redirectUri = url.toString()
+      url.hash = parsed.paramsString
+      newUrl = url.toString()
     }
 
     if (parsed?.oauthParams) {
       if (this.flow === 'standard' || this.flow === 'hybrid') {
         if ((parsed.oauthParams.code || parsed.oauthParams.error) && parsed.oauthParams.state) {
-          parsed.oauthParams.redirectUri = redirectUri
+          parsed.oauthParams.newUrl = newUrl
           return parsed.oauthParams
         }
       } else if (this.flow === 'implicit') {
         if ((parsed.oauthParams.access_token || parsed.oauthParams.error) && parsed.oauthParams.state) {
-          parsed.oauthParams.redirectUri = redirectUri
+          parsed.oauthParams.newUrl = newUrl
           return parsed.oauthParams
         }
       }

--- a/test/support/common.ts
+++ b/test/support/common.ts
@@ -2,6 +2,7 @@ export const APP_URL = new URL('http://localhost:3000')
 export const AUTH_SERVER_URL = new URL('http://localhost:8080')
 export const APP_URL_CROSS_ORIGIN = new URL('http://kjs-app.localhost:3000')
 export const AUTH_SERVER_URL_CROSS_ORIGIN = new URL('http://kjs-auth.localhost:8080')
+export const REDIRECT_SERVICE_URL = new URL('http://kjs-redirect.localhost:3000')
 export const ADMIN_USERNAME = 'admin'
 export const ADMIN_PASSWORD = 'admin'
 export const CLIENT_ID = 'keycloak-js-test-client'

--- a/test/tests/login-with-redirect.spec.ts
+++ b/test/tests/login-with-redirect.spec.ts
@@ -1,0 +1,38 @@
+import { expect } from '@playwright/test'
+import type { KeycloakInitOptions } from '../../lib/keycloak.js'
+import { REDIRECT_SERVICE_URL } from '../support/common.ts'
+import { createTestBed, test } from '../support/testbed.ts'
+
+/**
+ * This test simulates a scenario where a user has configured the adapter to use a redirect URL
+ * on a different domain than the application (e.g. a redirect service), which then redirects
+ * back to the actual application. This redirect sits between the application and the auth server.
+ */
+test('logs in with a redirect service between the application and auth server', async ({ page, appUrl, authServerUrl }) => {
+  const { executor, updateClient } = await createTestBed(page, { appUrl, authServerUrl })
+
+  // Update the client to allow redirecting to the redirect service.
+  await updateClient({
+    redirectUris: [`${appUrl.origin}/*`, `${REDIRECT_SERVICE_URL.origin}/*`]
+  })
+
+  // Build the redirect URL that points to the redirect service instead of the application.
+  const redirectUrl = new URL(REDIRECT_SERVICE_URL)
+  redirectUrl.searchParams.set('origin', appUrl.origin)
+
+  const initOptions: KeycloakInitOptions = {
+    ...executor.defaultInitOptions(),
+    redirectUri: redirectUrl.toString()
+  }
+
+  // Initially, no user should be authenticated.
+  expect(await executor.initializeAdapter(initOptions)).toBe(false)
+  expect(await executor.isAuthenticated()).toBe(false)
+
+  await executor.login()
+  await executor.submitLoginForm()
+
+  // After login, the user should be authenticated.
+  expect(await executor.initializeAdapter(initOptions)).toBe(true)
+  expect(await executor.isAuthenticated()).toBe(true)
+})


### PR DESCRIPTION
This fixes a regression that was introduced by 82924d01cf4d81f32fe63120a0d171d69cb8a4db, which has now been partially reverted, restoring the original behavior. A regression test has also been added to ensure correctness in the future.

Closes #189