### PR TITLE
Explicitly navigate to application page in tests

### DIFF
--- a/test/support/test-executor.ts
+++ b/test/support/test-executor.ts
@@ -37,10 +37,13 @@ export class TestExecutor {
     })
   }
 
+  async navigateToApp (): Promise<void> {
+    await this.#page.goto(this.#options.appUrl.toString())
+  }
+
   async instantiateAdapter (config: KeycloakConfig | string = this.defaultConfig()): Promise<void> {
     // Reset the console messages when instantiating the adapter.
     this.#consoleMessages = []
-    await this.#ensureOnAppPage()
     // Wait for the Keycloak constructor to be exposed globally by the app.
     // Sometimes the script that does so is not executed yet, so we need to wait for it.
     await this.#page.waitForFunction(() => 'Keycloak' in globalThis)
@@ -267,12 +270,6 @@ export class TestExecutor {
 
   async reload (): Promise<void> {
     await this.#page.reload()
-  }
-
-  async #ensureOnAppPage (): Promise<void> {
-    if (!this.#page.url().startsWith(this.#options.appUrl.origin)) {
-      await this.#page.goto(this.#options.appUrl.toString())
-    }
   }
 
   async #ensureInstantiated (): Promise<void> {

--- a/test/tests/account-url.spec.ts
+++ b/test/tests/account-url.spec.ts
@@ -4,6 +4,7 @@ import { createTestBed, test } from '../support/testbed.ts'
 
 test('creates an account URL with all options', async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const redirectUri = new URL('/foo/bar', appUrl)
   const accountUrl = new URL(await executor.createAccountUrl({
@@ -16,6 +17,7 @@ test('creates an account URL with all options', async ({ page, appUrl, authServe
 
 test('creates an account URL with default options', async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const accountUrl = new URL(await executor.createAccountUrl())
   expect(accountUrl.pathname).toBe(`/realms/${realm}/account`)
@@ -26,6 +28,7 @@ test('creates an account URL with default options', async ({ page, appUrl, authS
 test('throws creating an account URL using a generic OpenID provider', async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
   const oidcProviderUrl = new URL(`/realms/${realm}`, authServerUrl)
+  await executor.navigateToApp()
   await executor.instantiateAdapter({
     clientId: CLIENT_ID,
     oidcProvider: oidcProviderUrl.toString()

--- a/test/tests/implicit-flow.spec.ts
+++ b/test/tests/implicit-flow.spec.ts
@@ -7,6 +7,7 @@ test('logs in with an implicit flow', async ({ page, appUrl, authServerUrl }) =>
   const implicitFlow: KeycloakInitOptions = { ...executor.defaultInitOptions(), flow: 'implicit' }
   const standardFlow: KeycloakInitOptions = { ...executor.defaultInitOptions(), flow: 'standard' }
   // Initially, no user should be authenticated, and login should fail as implicit flow is disabled.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(implicitFlow)).toBe(false)
   await executor.login()
   await expect(executor.initializeAdapter(implicitFlow)).rejects.toMatchObject({
@@ -39,6 +40,7 @@ test('does not allow query response mode with an implicit flow', async ({ page, 
   }
   await updateClient({ implicitFlowEnabled: true, standardFlowEnabled: false })
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   // Attempting to log in should fail with an error indicating that the query response mode is not allowed for implicit flow.
   await executor.login()
@@ -56,6 +58,7 @@ test('fails refreshing a token for an implicit flow', async ({ page, appUrl, aut
   }
   await updateClient({ implicitFlowEnabled: true, standardFlowEnabled: false })
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await executor.login()
   await executor.submitLoginForm()
@@ -74,6 +77,7 @@ test('expires the access token with an implicit flow', async ({ page, appUrl, au
     flow: 'implicit'
   }
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await executor.login()
   await executor.submitLoginForm()

--- a/test/tests/init.spec.ts
+++ b/test/tests/init.spec.ts
@@ -3,6 +3,7 @@ import { createTestBed, test } from '../support/testbed.ts'
 
 test('throws when initializing multiple times', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter()
   await expect(executor.initializeAdapter()).rejects.toThrow("A 'Keycloak' instance can only be initialized once.")
 })

--- a/test/tests/login-url.spec.ts
+++ b/test/tests/login-url.spec.ts
@@ -5,6 +5,7 @@ import { createTestBed, test } from '../support/testbed.ts'
 
 test('creates a login URL with all options', async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const redirectUri = new URL('/foo/bar', appUrl)
   const loginUrl = new URL(await executor.createLoginUrl({
@@ -44,6 +45,7 @@ test('creates a login URL with all options', async ({ page, appUrl, authServerUr
 
 test('creates a login URL with default options', async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const loginUrl = new URL(await executor.createLoginUrl())
   expect(loginUrl.pathname).toBe(`/realms/${realm}/protocol/openid-connect/auth`)
@@ -68,6 +70,7 @@ test('creates a login URL with default options', async ({ page, appUrl, authServ
 
 test('creates a login URL to the registration page', async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const loginUrl = new URL(await executor.createLoginUrl({ action: 'register' }))
   expect(loginUrl.pathname).toBe(`/realms/${realm}/protocol/openid-connect/registrations`)
@@ -78,6 +81,7 @@ test('creates a login URL using the redirect URL passed during initialization', 
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const redirectUri = new URL('/foo/bar', appUrl)
   const initOptions: KeycloakInitOptions = { ...executor.defaultInitOptions(), redirectUri: redirectUri.toString() }
+  await executor.navigateToApp()
   await executor.initializeAdapter(initOptions)
   const loginUrl = new URL(await executor.createLoginUrl())
   expect(loginUrl.searchParams.get('redirect_uri')).toBe(redirectUri.toString())
@@ -86,6 +90,7 @@ test('creates a login URL using the redirect URL passed during initialization', 
 test('creates a login URL using the scope passed during initialization', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions: KeycloakInitOptions = { ...executor.defaultInitOptions(), scope: 'openid profile email' }
+  await executor.navigateToApp()
   await executor.initializeAdapter(initOptions)
   const loginUrl = new URL(await executor.createLoginUrl())
   expect(loginUrl.searchParams.get('scope')).toBe('openid profile email')
@@ -94,6 +99,7 @@ test('creates a login URL using the scope passed during initialization', async (
 test("creates a login URL with the 'openid' scope appended if omitted", async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions: KeycloakInitOptions = { ...executor.defaultInitOptions(), scope: 'profile email openidlike' }
+  await executor.navigateToApp()
   await executor.initializeAdapter(initOptions)
   const loginUrl = new URL(await executor.createLoginUrl())
   expect(loginUrl.searchParams.get('scope')).toBe('openid profile email openidlike')
@@ -102,6 +108,7 @@ test("creates a login URL with the 'openid' scope appended if omitted", async ({
 test('creates a login URL using the response mode passed during initialization', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions: KeycloakInitOptions = { ...executor.defaultInitOptions(), responseMode: 'query' }
+  await executor.navigateToApp()
   await executor.initializeAdapter(initOptions)
   const loginUrl = new URL(await executor.createLoginUrl())
   expect(loginUrl.searchParams.get('response_mode')).toBe('query')
@@ -110,6 +117,7 @@ test('creates a login URL using the response mode passed during initialization',
 test('creates a login URL based on the flow passed during initialization', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions: KeycloakInitOptions = { ...executor.defaultInitOptions(), flow: 'implicit' }
+  await executor.navigateToApp()
   await executor.initializeAdapter(initOptions)
   const loginUrl = new URL(await executor.createLoginUrl())
   expect(loginUrl.searchParams.get('response_type')).toBe('id_token token')
@@ -117,6 +125,7 @@ test('creates a login URL based on the flow passed during initialization', async
 
 test('creates a login URL with a max age of 0', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const loginUrl = new URL(await executor.createLoginUrl({ maxAge: 0 }))
   expect(loginUrl.searchParams.get('max_age')).toBe('0')

--- a/test/tests/login-with-redirect.spec.ts
+++ b/test/tests/login-with-redirect.spec.ts
@@ -26,6 +26,7 @@ test('logs in with a redirect service between the application and auth server', 
   }
 
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   expect(await executor.isAuthenticated()).toBe(false)
 

--- a/test/tests/login.spec.ts
+++ b/test/tests/login.spec.ts
@@ -7,6 +7,7 @@ test('logs in and out with default configuration', async ({ page, appUrl, authSe
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions = executor.defaultInitOptions()
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   expect(await executor.isAuthenticated()).toBe(false)
   await executor.login()
@@ -26,6 +27,7 @@ test('logs in and out using a URL to the adapter config', async ({ page, appUrl,
   const configUrl = new URL('/adapter-config.json', appUrl)
   configUrl.searchParams.set('realm', realm)
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   await executor.instantiateAdapter(configUrl.toString())
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await executor.login()
@@ -47,6 +49,7 @@ test('logs in and out using a generic OpenID provider', async ({ page, appUrl, a
     oidcProvider: new URL(`/realms/${realm}`, authServerUrl).toString()
   }
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   await executor.instantiateAdapter(configOptions)
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await executor.login()
@@ -63,6 +66,7 @@ test('logs in and out using a generic OpenID provider', async ({ page, appUrl, a
 test('logs in and out without initialization options', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter()).toBe(false)
   await executor.login()
   await executor.submitLoginForm()
@@ -77,6 +81,7 @@ test('logs in and out without PKCE', async ({ page, appUrl, authServerUrl }) => 
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions: KeycloakInitOptions = { ...executor.defaultInitOptions(), pkceMethod: false }
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await executor.login()
   await executor.submitLoginForm()
@@ -91,6 +96,7 @@ test("logs in and out with 'POST' logout configured at initialization", async ({
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions: KeycloakInitOptions = { ...executor.defaultInitOptions(), logoutMethod: 'POST' }
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await executor.login()
   await executor.submitLoginForm()
@@ -105,6 +111,7 @@ test("logs in and out with 'POST' logout configured at logout", async ({ page, a
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions = executor.defaultInitOptions()
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await executor.login()
   await executor.submitLoginForm()
@@ -119,6 +126,7 @@ test('logs in and checks session status', async ({ page, appUrl, authServerUrl, 
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions = executor.defaultInitOptions()
   // Trigger login and initialize the adapter to check session status.
+  await executor.navigateToApp()
   await executor.initializeAdapter(initOptions)
   await executor.login()
   await executor.submitLoginForm()
@@ -134,6 +142,7 @@ test("logs in and out with onLoad set to 'login-required'", async ({ page, appUr
     onLoad: 'login-required'
   }
   // Initially, no user should be authenticated, and a redirect to the login page should occur.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions, true)).toBe(false)
   await executor.submitLoginForm()
   // After triggering a login, the user should be authenticated.
@@ -150,6 +159,7 @@ test("logs in and out with onLoad set to 'check-sso'", async ({ page, appUrl, au
     onLoad: 'check-sso'
   }
   // Initially, no user should be authenticated, and a redirect should occur in a strict cookie environment.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions, strictCookies)).toBe(false)
   await executor.login()
   await executor.submitLoginForm()

--- a/test/tests/logout-url.spec.ts
+++ b/test/tests/logout-url.spec.ts
@@ -5,6 +5,7 @@ import { createTestBed, test } from '../support/testbed.ts'
 
 test('creates a logout URL with all options', async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const redirectUri = new URL('/foo/bar', appUrl)
   const logoutUrl = new URL(await executor.createLogoutUrl({
@@ -19,6 +20,7 @@ test('creates a logout URL with all options', async ({ page, appUrl, authServerU
 
 test('creates a logout URL with default options', async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const logoutUrl = new URL(await executor.createLogoutUrl())
   expect(logoutUrl.pathname).toBe(`/realms/${realm}/protocol/openid-connect/logout`)
@@ -29,6 +31,7 @@ test('creates a logout URL with default options', async ({ page, appUrl, authSer
 
 test("creates a logout URL with 'POST' method", async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const redirectUri = new URL('/foo/bar', appUrl)
   const logoutUrl = new URL(await executor.createLogoutUrl({
@@ -45,6 +48,7 @@ test('creates a logout URL using the redirect URL passed during initialization',
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const redirectUri = new URL('/foo/bar', appUrl)
   const initOptions: KeycloakInitOptions = { ...executor.defaultInitOptions(), redirectUri: redirectUri.toString() }
+  await executor.navigateToApp()
   await executor.initializeAdapter(initOptions)
   const logoutUrl = new URL(await executor.createLogoutUrl())
   expect(logoutUrl.searchParams.get('post_logout_redirect_uri')).toBe(redirectUri.toString())
@@ -52,6 +56,7 @@ test('creates a logout URL using the redirect URL passed during initialization',
 
 test('creates a logout URL with the ID token hint when authenticated', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter()
   await executor.login()
   await executor.submitLoginForm()

--- a/test/tests/register-url.spec.ts
+++ b/test/tests/register-url.spec.ts
@@ -6,6 +6,7 @@ import { createTestBed, test } from '../support/testbed.ts'
 
 test('creates a registration URL with all options', async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const redirectUri = new URL('/foo/bar', appUrl)
   const registerUrl = new URL(await executor.createRegisterUrl({
@@ -44,6 +45,7 @@ test('creates a registration URL with all options', async ({ page, appUrl, authS
 
 test('creates a registration URL with default options', async ({ page, appUrl, authServerUrl }) => {
   const { executor, realm } = await createTestBed(page, { appUrl, authServerUrl })
+  await executor.navigateToApp()
   await executor.initializeAdapter(executor.defaultInitOptions())
   const registerUrl = new URL(await executor.createRegisterUrl())
   expect(registerUrl.pathname).toBe(`/realms/${realm}/protocol/openid-connect/registrations`)

--- a/test/tests/scope.spec.ts
+++ b/test/tests/scope.spec.ts
@@ -10,6 +10,7 @@ test('logs in and obtains scopes passed in during initialization', async ({ page
     scope: 'openid profile email phone'
   }
   // Initially, no user should be authenticated, and a redirect to the login page should occur.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions, true)).toBe(false)
   await executor.submitLoginForm()
   // After triggering a login, the user should be authenticated, and the provided scopes should be present.
@@ -25,6 +26,7 @@ test('logs in and obtains scopes passed in during login', async ({ page, appUrl,
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions = executor.defaultInitOptions()
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await executor.login({
     scope: 'openid profile email phone'

--- a/test/tests/silent-sso.spec.ts
+++ b/test/tests/silent-sso.spec.ts
@@ -10,6 +10,7 @@ test('logs in with a silent SSO redirect', async ({ page, appUrl, authServerUrl,
     silentCheckSsoRedirectUri: executor.silentSSORedirectUrl().toString()
   }
   // Initially, no user should be authenticated, and a redirect should occur in a strict cookie environment.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions, strictCookies)).toBe(false)
   await executor.login()
   await executor.submitLoginForm()
@@ -29,6 +30,7 @@ test('logs in with a silent SSO redirect and login iframe disabled', async ({ pa
     checkLoginIframe: false
   }
   // Initially, no user should be authenticated, and a redirect should occur in a strict cookie environment.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions, strictCookies)).toBe(false)
   await executor.login()
   await executor.submitLoginForm()
@@ -48,6 +50,7 @@ test('logs in with a silent SSO redirect and fallback disabled', async ({ page, 
     silentCheckSsoFallback: false
   }
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await executor.login()
   await executor.submitLoginForm()

--- a/test/tests/token.spec.ts
+++ b/test/tests/token.spec.ts
@@ -6,6 +6,7 @@ test('refreshes a token', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions = executor.defaultInitOptions()
   // Initially, no user should be authenticated and refreshing the token should fail.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await expect(executor.updateToken(9999)).rejects.toThrow('Unable to update token, no refresh token available.')
   await executor.login()
@@ -19,6 +20,7 @@ test('refreshes a token with login iframe disabled', async ({ page, appUrl, auth
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions: KeycloakInitOptions = { ...executor.defaultInitOptions(), checkLoginIframe: false }
   // Initially, no user should be authenticated and refreshing the token should fail.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await expect(executor.updateToken(9999)).rejects.toThrow('Unable to update token, no refresh token available.')
   await executor.login()
@@ -33,6 +35,7 @@ test('refreshes a token only if outside of expiry', async ({ page, appUrl, authS
   const initOptions = executor.defaultInitOptions()
   await updateRealm({ accessTokenLifespan: 35 })
   // Initially, no user should be authenticated.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await executor.login()
   await executor.submitLoginForm()

--- a/test/tests/user-info.spec.ts
+++ b/test/tests/user-info.spec.ts
@@ -6,6 +6,7 @@ test('loads the user info', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions = executor.defaultInitOptions()
   // Initially, no user should be authenticated and loading the user info should fail.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await expect(executor.loadUserInfo()).rejects.toThrow('Unable to build authorization header, token is not set, make sure the user is authenticated.')
   await executor.login()

--- a/test/tests/user-profile.spec.ts
+++ b/test/tests/user-profile.spec.ts
@@ -7,6 +7,7 @@ test('loads the user profile', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions = executor.defaultInitOptions()
   // Initially, no user should be authenticated and loading the user profile should fail.
+  await executor.navigateToApp()
   expect(await executor.initializeAdapter(initOptions)).toBe(false)
   await expect(executor.loadUserProfile()).rejects.toThrow('Unable to build authorization header, token is not set, make sure the user is authenticated.')
   await executor.login()
@@ -25,6 +26,7 @@ test('throws loading the user profile using a generic OpenID provider', async ({
     oidcProvider: new URL(`/realms/${realm}`, authServerUrl).toString()
   }
   const initOptions = executor.defaultInitOptions()
+  await executor.navigateToApp()
   await executor.instantiateAdapter(configOptions)
   await executor.initializeAdapter(initOptions)
   await executor.login()


### PR DESCRIPTION
Changes the test executor, so that initial navigation to the application page only happens when done manually. This prevents automatic navigation later in the test that could cause a test to pass, even if should be failing.


Closes #232