### PR TITLE
Preserve URL hash on 'fragment' response

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -1090,19 +1090,30 @@ export default class Keycloak {
    * @returns {ParsedCallbackParams}
    */
   #parseCallbackParams (paramsString, supportedParams) {
-    const params = new URLSearchParams(paramsString)
+    const params = paramsString.split('&')
     /** @type {Record<string, string>} */
     const oauthParams = {}
+    let result = ''
 
-    for (const [key, value] of Array.from(params.entries())) {
-      if (supportedParams.includes(key)) {
+    for (const param of params.reverse()) {
+      const entry = new URLSearchParams(param).entries().next().value
+
+      if (!entry) {
+        result = '&' + result
+        continue
+      }
+
+      const [key, value] = entry
+
+      if (supportedParams.includes(key) && !(key in oauthParams)) {
         oauthParams[key] = value
-        params.delete(key)
+      } else {
+        result = result.length === 0 ? param : param + '&' + result
       }
     }
 
     return {
-      paramsString: params.toString(),
+      paramsString: result,
       oauthParams
     }
   }

--- a/test/tests/preserves-fragment.spec.ts
+++ b/test/tests/preserves-fragment.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 import { createTestBed, test } from '../support/testbed.ts'
 
-test('preserves URL fragment after login and logout', async ({ page, appUrl, authServerUrl }) => {
+test('preserves basic URL fragment', async ({ page, appUrl, authServerUrl }) => {
   const { executor } = await createTestBed(page, { appUrl, authServerUrl })
   const initOptions = executor.defaultInitOptions()
   const fragment = '#section=preserved'
@@ -20,9 +20,104 @@ test('preserves URL fragment after login and logout', async ({ page, appUrl, aut
   // After login and adapter initialization, the URL fragment should be preserved.
   await executor.initializeAdapter(initOptions)
   expect(new URL(await page.url()).hash).toBe(fragment)
+})
 
-  // After logout, the URL fragment should still be preserved.
-  await executor.logout()
+test('preserves fragment with conflicting (known oauth) params', async ({ page, appUrl, authServerUrl }) => {
+  const { executor } = await createTestBed(page, { appUrl, authServerUrl })
+  const initOptions = executor.defaultInitOptions()
+  const fragment = '#state=anotherValue'
+  const appUrlWithFragment = new URL(appUrl)
+
+  appUrlWithFragment.hash = fragment
+
+  await page.goto(appUrlWithFragment.toString())
+
+  // Initialize the adapter and perform login.
+  await executor.initializeAdapter(initOptions)
+  await executor.login()
+  await executor.submitLoginForm()
+
+  // After login and adapter initialization, the URL fragment should be preserved.
+  await executor.initializeAdapter(initOptions)
+  expect(new URL(await page.url()).hash).toBe(fragment)
+})
+
+test('preserves path-style URL fragment', async ({ page, appUrl, authServerUrl }) => {
+  const { executor } = await createTestBed(page, { appUrl, authServerUrl })
+  const initOptions = executor.defaultInitOptions()
+  const fragment = '#/admin/users'
+  const appUrlWithFragment = new URL(appUrl)
+
+  appUrlWithFragment.hash = fragment
+
+  await page.goto(appUrlWithFragment.toString())
+
+  // Initialize the adapter and perform login.
+  await executor.initializeAdapter(initOptions)
+  await executor.login()
+  await executor.submitLoginForm()
+
+  // After login and adapter initialization, the URL fragment should be preserved.
+  await executor.initializeAdapter(initOptions)
+  expect(new URL(await page.url()).hash).toBe(fragment)
+})
+
+test('preserves path-style fragment with query params', async ({ page, appUrl, authServerUrl }) => {
+  const { executor } = await createTestBed(page, { appUrl, authServerUrl })
+  const initOptions = executor.defaultInitOptions()
+  const fragment = '#/admin/users?tab=details&sort=asc'
+  const appUrlWithFragment = new URL(appUrl)
+
+  appUrlWithFragment.hash = fragment
+
+  await page.goto(appUrlWithFragment.toString())
+
+  // Initialize the adapter and perform login.
+  await executor.initializeAdapter(initOptions)
+  await executor.login()
+  await executor.submitLoginForm()
+
+  // After login and adapter initialization, the URL fragment should be preserved.
+  await executor.initializeAdapter(initOptions)
+  expect(new URL(await page.url()).hash).toBe(fragment)
+})
+
+test('preserves fragment with leading question mark', async ({ page, appUrl, authServerUrl }) => {
+  const { executor } = await createTestBed(page, { appUrl, authServerUrl })
+  const initOptions = executor.defaultInitOptions()
+  const fragment = '#?tab=details'
+  const appUrlWithFragment = new URL(appUrl)
+
+  appUrlWithFragment.hash = fragment
+
+  await page.goto(appUrlWithFragment.toString())
+
+  // Initialize the adapter and perform login.
+  await executor.initializeAdapter(initOptions)
+  await executor.login()
+  await executor.submitLoginForm()
+
+  // After login and adapter initialization, the URL fragment should be preserved.
+  await executor.initializeAdapter(initOptions)
+  expect(new URL(await page.url()).hash).toBe(fragment)
+})
+
+test('preserves fragment with multiple ampersands', async ({ page, appUrl, authServerUrl }) => {
+  const { executor } = await createTestBed(page, { appUrl, authServerUrl })
+  const initOptions = executor.defaultInitOptions()
+  const fragment = '#&&foo=bar&&baz=qux&=bax&fuz='
+  const appUrlWithFragment = new URL(appUrl)
+
+  appUrlWithFragment.hash = fragment
+
+  await page.goto(appUrlWithFragment.toString())
+
+  // Initialize the adapter and perform login.
+  await executor.initializeAdapter(initOptions)
+  await executor.login()
+  await executor.submitLoginForm()
+
+  // After login and adapter initialization, the URL fragment should be preserved.
   await executor.initializeAdapter(initOptions)
   expect(new URL(await page.url()).hash).toBe(fragment)
 })


### PR DESCRIPTION
Fixes an issue where URL fragments with path-style routing (e.g., `#/admin/maintenance/scripts`) were being URL-encoded after OAuth callback, breaking some applications using hash-based routing. The fix correctly separates the application portion of the hash (e.g. routes) from OAuth callback parameters in fragment response.

Closes #241