### PR TITLE
Parsed token `amr` claim is an array of strings

### DIFF
--- a/lib/keycloak.d.ts
+++ b/lib/keycloak.d.ts
@@ -366,7 +366,7 @@ export interface KeycloakTokenParsed {
   auth_time?: number
   nonce?: string
   acr?: string
-  amr?: string
+  amr?: string[]
   azp?: string
   session_state?: string
   realm_access?: KeycloakRoles


### PR DESCRIPTION
Keycloak server actually returns it as a JSON **array** (`string[]`) per [RFC 8176](https://datatracker.ietf.org/doc/html/rfc8176)

Closes #254