### PR TITLE
Bind Podman ports on IPv6 to support loopback resolution

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -80,7 +80,7 @@ npm test -- --debug
 By default, the tests will run against a Keycloak server that is running the latest version. This server is started by Playwright using Podman by running the following command:
 
 ```sh
-podman run -p 8080:8080 -p 9000:9000 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -e KC_HEALTH_ENABLED=true --pull=newer quay.io/keycloak/keycloak:latest start-dev
+podman run -p '[::]:8080:8080' -p '[::]:9000:9000' -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -e KC_HEALTH_ENABLED=true --pull=newer quay.io/keycloak/keycloak:latest start-dev
 ```
 
 Alternatively, if you want to run the Keycloak server straight from the distribution (or your local development instance), without using Podman you can run it as follows:

--- a/test/playwright.config.ts
+++ b/test/playwright.config.ts
@@ -7,7 +7,7 @@ const KEYCLOAK_VERSION = 'latest'
 export default defineConfig<TestOptions>({
   fullyParallel: true,
   webServer: [{
-    command: `podman run -p 8080:8080 -p 9000:9000 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -e KC_HEALTH_ENABLED=true --pull=newer quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} start-dev`,
+    command: `podman run -p [::]:8080:8080 -p [::]:9000:9000 -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin -e KC_HEALTH_ENABLED=true --pull=newer quay.io/keycloak/keycloak:${KEYCLOAK_VERSION} start-dev`,
     url: 'http://localhost:9000/health/live',
     stdout: 'pipe',
     reuseExistingServer: true,


### PR DESCRIPTION
Binds ports on `[::]` (IPv6) instead of the default `0.0.0.0` (IPv4 only) when starting the Keycloak container for tests. This ensures `localhost` resolves correctly regardless of whether the system prefers IPv4 or IPv6.

Closes #268