### PR TITLE
Close in-app browser before awaiting token exchange in Cordova adapter

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -442,15 +442,15 @@ export default class Keycloak {
           ref.addEventListener('loadstart', async (event) => {
             if (event.url.indexOf(getCordovaRedirectUri()) === 0) {
               const callback = this.#parseCallback(event.url)
+              completed = true
+              closeBrowser()
 
               try {
-                completed = true
                 await this.#processCallback(callback)
                 resolve()
               } catch (error) {
                 reject(error)
               }
-              closeBrowser()
             }
           })
 
@@ -458,14 +458,15 @@ export default class Keycloak {
             if (!completed) {
               if (event.url.indexOf(getCordovaRedirectUri()) === 0) {
                 const callback = this.#parseCallback(event.url)
+                completed = true
+                closeBrowser()
+
                 try {
                   await this.#processCallback(callback)
                   resolve()
                 } catch (error) {
                   reject(error)
                 }
-                closeBrowser()
-                completed = true
               } else {
                 reject(new Error('Unable to process login.'))
                 closeBrowser()


### PR DESCRIPTION
Fixes a regression introduced in 26.2.1 (#102) where the Cordova in-app browser stays open during the async token exchange, causing Android to briefly flash a "Web page not available" error before the browser closes.

Closes #209
