### PR TITLE
Validate OAuth state in Cordova adapter login callbacks

### DIFF
--- a/lib/keycloak.js
+++ b/lib/keycloak.js
@@ -449,6 +449,11 @@ export default class Keycloak {
               completed = true
               closeBrowser()
 
+              if (!callback || !callback.valid) {
+                reject(new Error('Invalid OAuth state in login callback.'))
+                return
+              }
+
               try {
                 await this.#processCallback(callback)
                 resolve()
@@ -464,6 +469,11 @@ export default class Keycloak {
                 const callback = this.#parseCallback(event.url)
                 completed = true
                 closeBrowser()
+
+                if (!callback || !callback.valid) {
+                  reject(new Error('Invalid OAuth state in login callback.'))
+                  return
+                }
 
                 try {
                   await this.#processCallback(callback)
@@ -530,6 +540,11 @@ export default class Keycloak {
               ref.close()
               const oauth = this.#parseCallback(event.url)
 
+              if (!oauth || !oauth.valid) {
+                reject(new Error('Invalid OAuth state in register callback.'))
+                return
+              }
+
               try {
                 await this.#processCallback(oauth)
                 resolve()
@@ -578,6 +593,11 @@ export default class Keycloak {
             window.cordova.plugins.browsertab.close()
             const oauth = this.#parseCallback(event.url)
 
+            if (!oauth || !oauth.valid) {
+              reject(new Error('Invalid OAuth state in login callback.'))
+              return
+            }
+
             try {
               await this.#processCallback(oauth)
               resolve()
@@ -613,6 +633,12 @@ export default class Keycloak {
             universalLinks.unsubscribe('keycloak')
             window.cordova.plugins.browsertab.close()
             const oauth = this.#parseCallback(event.url)
+
+            if (!oauth || !oauth.valid) {
+              reject(new Error('Invalid OAuth state in register callback.'))
+              return
+            }
+
             try {
               await this.#processCallback(oauth)
               resolve()


### PR DESCRIPTION
The `cordova` and `cordova-native` adapters call `#processCallback` without checking `oauth.valid` after parsing the callback URL. The default adapter gates on this flag in `#processInit`, but the Cordova adapters skip it entirely. This means a forged callback with a mismatched or missing `state` parameter gets processed as if it were legitimate.

This adds the same `oauth.valid` check before every `#processCallback` call in both adapters, covering login (`loadstart` and `loaderror`) and register paths for cordova, and login and register for cordova-native. Invalid state now results in a rejected promise with a descriptive error.

Closes #306